### PR TITLE
Enable file upload for Storage api

### DIFF
--- a/clients/storage/README.md
+++ b/clients/storage/README.md
@@ -1,6 +1,6 @@
 # GoogleApi.Storage.V1
 
-**TODO: Add description**
+Stores and retrieves potentially large, immutable data objects.
 
 ## Installation
 

--- a/clients/storage/lib/google_api/storage/v1/api/buckets.ex
+++ b/clients/storage/lib/google_api/storage/v1/api/buckets.ex
@@ -207,7 +207,7 @@ defmodule GoogleApi.Storage.V1.Api.Buckets do
     }
     %{}
     |> method(:post)
-    |> url("/b")
+    |> url("/storage/v1/b")
     |> add_param(:query, :"project", project)
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
@@ -257,7 +257,7 @@ defmodule GoogleApi.Storage.V1.Api.Buckets do
     }
     %{}
     |> method(:get)
-    |> url("/b")
+    |> url("/storage/v1/b")
     |> add_param(:query, :"project", project)
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])

--- a/clients/storage/lib/google_api/storage/v1/api/objects.ex
+++ b/clients/storage/lib/google_api/storage/v1/api/objects.ex
@@ -441,7 +441,9 @@ defmodule GoogleApi.Storage.V1.Api.Objects do
 
   - connection (GoogleApi.Storage.V1.Connection): Connection to server
   - bucket (String): Name of the bucket in which to store the new object. Overrides the provided object metadata&#39;s bucket value, if any.
-  - upload_type (String): Upload type
+  - upload_type (String): Upload type. Must be \&quot;multipart\&quot;.
+  - metadata (Object): Object metadata
+  - data (String): The file to upload
   - opts (KeywordList): [optional] Optional parameters
     - :alt (String): Data format for the response.
     - :fields (String): Selector specifying which fields to include in a partial response.
@@ -460,15 +462,14 @@ defmodule GoogleApi.Storage.V1.Api.Objects do
     - :predefined_acl (String): Apply a predefined set of access controls to this object.
     - :projection (String): Set of properties to return. Defaults to noAcl, unless the object resource specifies the acl property, when it defaults to full.
     - :user_project (String): The project to be billed for this request, for Requester Pays buckets.
-    - :body (Object): 
 
   ## Returns
 
   {:ok, %GoogleApi.Storage.V1.Model.Object{}} on success
   {:error, info} on failure
   """
-  @spec storage_objects_insert_simple(Tesla.Env.client, String.t, String.t, keyword()) :: {:ok, GoogleApi.Storage.V1.Model.Object.t} | {:error, Tesla.Env.t}
-  def storage_objects_insert_simple(connection, bucket, upload_type, opts \\ []) do
+  @spec storage_objects_insert_simple(Tesla.Env.client, String.t, String.t, GoogleApi.Storage.V1.Model.Object.t, String.t, keyword()) :: {:ok, GoogleApi.Storage.V1.Model.Object.t} | {:error, Tesla.Env.t}
+  def storage_objects_insert_simple(connection, bucket, upload_type, metadata, data, opts \\ []) do
     optional_params = %{
       :"alt" => :query,
       :"fields" => :query,
@@ -486,13 +487,14 @@ defmodule GoogleApi.Storage.V1.Api.Objects do
       :"name" => :query,
       :"predefinedAcl" => :query,
       :"projection" => :query,
-      :"userProject" => :query,
-      :"body" => :body
+      :"userProject" => :query
     }
     %{}
     |> method(:post)
     |> url("/upload/storage/v1/b/#{bucket}/o")
     |> add_param(:query, :"uploadType", upload_type)
+    |> add_param(:body, :"metadata", metadata)
+    |> add_param(:file, :"data", data)
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()

--- a/clients/storage/lib/google_api/storage/v1/model/bucket.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket.ex
@@ -66,4 +66,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Bucket do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_access_control.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_access_control.ex
@@ -46,4 +46,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.BucketAccessControl do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_access_control_project_team.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_access_control_project_team.ex
@@ -30,10 +30,8 @@ defmodule GoogleApi.Storage.V1.Model.BucketAccessControl_projectTeam do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.BucketAccessControl_projectTeam do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_access_controls.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_access_controls.ex
@@ -37,4 +37,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.BucketAccessControls do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_billing.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_billing.ex
@@ -29,10 +29,8 @@ defmodule GoogleApi.Storage.V1.Model.Bucket_billing do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Bucket_billing do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_cors.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_cors.ex
@@ -32,10 +32,8 @@ defmodule GoogleApi.Storage.V1.Model.Bucket_cors do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Bucket_cors do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_encryption.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_encryption.ex
@@ -29,10 +29,8 @@ defmodule GoogleApi.Storage.V1.Model.Bucket_encryption do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Bucket_encryption do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_lifecycle.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_lifecycle.ex
@@ -36,4 +36,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Bucket_lifecycle do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_lifecycle_action.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_lifecycle_action.ex
@@ -30,10 +30,8 @@ defmodule GoogleApi.Storage.V1.Model.Bucket_lifecycle_action do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Bucket_lifecycle_action do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_lifecycle_condition.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_lifecycle_condition.ex
@@ -40,4 +40,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Bucket_lifecycle_conditi
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_lifecycle_rule.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_lifecycle_rule.ex
@@ -38,4 +38,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Bucket_lifecycle_rule do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_logging.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_logging.ex
@@ -30,10 +30,8 @@ defmodule GoogleApi.Storage.V1.Model.Bucket_logging do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Bucket_logging do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_owner.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_owner.ex
@@ -30,10 +30,8 @@ defmodule GoogleApi.Storage.V1.Model.Bucket_owner do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Bucket_owner do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_versioning.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_versioning.ex
@@ -29,10 +29,8 @@ defmodule GoogleApi.Storage.V1.Model.Bucket_versioning do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Bucket_versioning do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/bucket_website.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/bucket_website.ex
@@ -30,10 +30,8 @@ defmodule GoogleApi.Storage.V1.Model.Bucket_website do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Bucket_website do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/buckets.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/buckets.ex
@@ -38,4 +38,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Buckets do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/channel.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/channel.ex
@@ -38,10 +38,8 @@ defmodule GoogleApi.Storage.V1.Model.Channel do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Channel do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/compose_request.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/compose_request.ex
@@ -39,4 +39,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.ComposeRequest do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/compose_request_object_preconditions.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/compose_request_object_preconditions.ex
@@ -29,10 +29,8 @@ defmodule GoogleApi.Storage.V1.Model.ComposeRequest_objectPreconditions do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.ComposeRequest_objectPreconditions do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/compose_request_source_objects.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/compose_request_source_objects.ex
@@ -38,4 +38,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.ComposeRequest_sourceObj
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/notification.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/notification.ex
@@ -37,10 +37,8 @@ defmodule GoogleApi.Storage.V1.Model.Notification do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Notification do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/notifications.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/notifications.ex
@@ -37,4 +37,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Notifications do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/object.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/object.ex
@@ -65,4 +65,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Object do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/object_access_control.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/object_access_control.ex
@@ -48,4 +48,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.ObjectAccessControl do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/object_access_controls.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/object_access_controls.ex
@@ -37,4 +37,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.ObjectAccessControls do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/object_customer_encryption.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/object_customer_encryption.ex
@@ -30,10 +30,8 @@ defmodule GoogleApi.Storage.V1.Model.Object_customerEncryption do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Object_customerEncryption do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/object_owner.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/object_owner.ex
@@ -30,10 +30,8 @@ defmodule GoogleApi.Storage.V1.Model.Object_owner do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Object_owner do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/objects.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/objects.ex
@@ -39,4 +39,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Objects do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/policy.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/policy.ex
@@ -39,4 +39,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Policy do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/policy_bindings.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/policy_bindings.ex
@@ -30,10 +30,8 @@ defmodule GoogleApi.Storage.V1.Model.Policy_bindings do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.Policy_bindings do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/rewrite_response.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/rewrite_response.ex
@@ -41,4 +41,3 @@ defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.RewriteResponse do
   end
 end
 
-

--- a/clients/storage/lib/google_api/storage/v1/model/service_account.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/service_account.ex
@@ -30,10 +30,8 @@ defmodule GoogleApi.Storage.V1.Model.ServiceAccount do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.ServiceAccount do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/model/test_iam_permissions_response.ex
+++ b/clients/storage/lib/google_api/storage/v1/model/test_iam_permissions_response.ex
@@ -30,10 +30,8 @@ defmodule GoogleApi.Storage.V1.Model.TestIamPermissionsResponse do
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Storage.V1.Model.TestIamPermissionsResponse do
-  import GoogleApi.Storage.V1.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
   end
 end
-
 

--- a/clients/storage/lib/google_api/storage/v1/request_builder.ex
+++ b/clients/storage/lib/google_api/storage/v1/request_builder.ex
@@ -98,6 +98,20 @@ defmodule GoogleApi.Storage.V1.RequestBuilder do
   """
   @spec add_param(map(), :atom, :atom, any()) :: map()
   def add_param(request, :body, :body, value), do: Map.put(request, :body, value)
+  def add_param(request, :body, key, value) do
+    request
+    |> Map.put_new_lazy(:body, &Tesla.Multipart.new/0)
+    |> Map.update!(:body, &(Tesla.Multipart.add_field(&1, key, Poison.encode!(value), headers: [{:"Content-Type", "application/json"}])))
+  end
+  def add_param(request, :file, name, path) do
+    request
+    |> Map.put_new_lazy(:body, &Tesla.Multipart.new/0)
+    |> Map.update!(:body, &(Tesla.Multipart.add_file(&1, path, name: name)))
+  end
+  def add_param(request, :form, name, value) do
+    request
+    |> Map.update(:body, %{name => value}, &(Map.put(&1, name, value)))
+  end
   def add_param(request, location, key, value) do
     Map.update(request, location, [{key, value}], &(&1 ++ [{key, value}]))
   end

--- a/clients/storage/mix.exs
+++ b/clients/storage/mix.exs
@@ -1,36 +1,49 @@
 defmodule GoogleApi.Storage.V1.Mixfile do
   use Mix.Project
 
-  def project do
-    [app: :google_api_storage,
-     version: "0.1.0",
-     elixir: "~> 1.4",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps()]
+  @version "0.0.1"
+
+  def project() do
+    [
+      app: :google_api_storage,
+      version: @version,
+      elixir: "~> 1.4",
+      build_embedded: Mix.env == :prod,
+      start_permanent: Mix.env == :prod,
+      description: description(),
+      package: package(),
+      deps: deps(),
+      source_url: "https://github.com/GoogleCloudPlatform/elixir-google-api/tree/master/clients/storage"
+    ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
-  def application do
-    # Specify extra applications you'll use from Erlang/Elixir
+  def application() do
     [extra_applications: [:logger]]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:my_dep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
-  defp deps do
+  defp deps() do
     [
-      {:tesla, "~> 0.5"},
-      {:poison, ">= 1.0.0"}
+      {:tesla, "~> 0.8"},
+      {:poison, ">= 1.0.0"},
+      {:ex_doc, "~> 0.16", only: :dev}
+    ]
+  end
+
+  defp description() do
+    """
+    Stores and retrieves potentially large, immutable data objects.
+    """
+  end
+
+  defp package() do
+    [
+      files: ["lib", "mix.exs", "README*", "LICENSE"],
+      maintainers: ["Jeff Ching"],
+      licenses: ["Apache 2.0"],
+      links: %{
+        "GitHub" => "https://github.com/GoogleCloudPlatform/elixir-google-api/tree/master/clients/storage",
+        "Homepage" => "https://cloud.google.comstorage/"
+      }
     ]
   end
 end

--- a/clients/storage/mix.exs
+++ b/clients/storage/mix.exs
@@ -42,7 +42,7 @@ defmodule GoogleApi.Storage.V1.Mixfile do
       licenses: ["Apache 2.0"],
       links: %{
         "GitHub" => "https://github.com/GoogleCloudPlatform/elixir-google-api/tree/master/clients/storage",
-        "Homepage" => "https://cloud.google.comstorage/"
+        "Homepage" => "https://cloud.google.com/storage/"
       }
     ]
   end


### PR DESCRIPTION
The generated code now handles required multipart form fields:

```elixir
object = %Object{name: filename, bucket: "my-bucket"}
GoogleApi.Storage.V1.Api.Objects.storage_objects_insert_simple(api_connection, "my-bucket", "multipart", object, "/path/to/file")
```