### PR TITLE
Fixed not writing specs to directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,19 @@ The default generator uses Docker and an image based off the [swagger-codegen pr
 You can further configure this converter by modifying the `config/config.exs` setting:
 
 ```elixir
-config :google_apis, swagger_cli_image: "swagger-cli"
+config :google_apis, swagger_cli_image: "swaggerapi/swagger-codegen-cli"
+```
+
+To get the current version of swagger cli:
+
+```bash
+docker pull swaggerapi/swagger-codegen-cli
 ```
 
 You can also limit which APIs to generate by providing an API name argument to the mix task:
 
 ```bash
-$> mix google_apis.generate CloudTrace
+$> mix google_apis.build CloudTrace
 ```
 
 ## Contributing

--- a/config/config.exs
+++ b/config/config.exs
@@ -29,7 +29,7 @@ use Mix.Config
 #
 #     import_config "#{Mix.env}.exs"
 
-config :google_apis, 
+config :google_apis,
   spec_converter: GoogleApis.Converter.ApiSpecConverter,
   client_generator: GoogleApis.Generator.SwaggerCli,
-  swagger_cli_image: "swagger-cli"
+  swagger_cli_image: "swaggerapi/swagger-codegen-cli"

--- a/lib/google_apis.ex
+++ b/lib/google_apis.ex
@@ -51,7 +51,7 @@ defmodule GoogleApis do
   def fetch(api_config) do
     file = ApiConfig.google_spec_file(api_config)
 
-    with {:ok, body} = GoogleApis.Discovery.fetch(api_config.url),
+    with {:ok, body} = GoogleApis.Discovery.fetch(api_config.discoveryRestUrl),
          :ok <- File.mkdir_p(Path.dirname(file)),
          :ok <- File.write(file, body)
     do

--- a/lib/google_apis.ex
+++ b/lib/google_apis.ex
@@ -51,13 +51,31 @@ defmodule GoogleApis do
   def fetch(api_config) do
     file = ApiConfig.google_spec_file(api_config)
 
-    with {:ok, body} = GoogleApis.Discovery.fetch(api_config.discoveryRestUrl),
-         :ok <- File.mkdir_p(Path.dirname(file)),
-         :ok <- File.write(file, body)
-    do
-      {:ok, file}
+    case GoogleApis.Discovery.fetch(api_config.discoveryRestUrl) do
+      {:ok, body} ->
+        case File.mkdir_p(Path.dirname(file)) do
+          :ok ->
+            case File.write(file, body) do
+              :ok ->
+                {:ok, file}
+              {:error, posix} ->
+                msg = "Cannot write file. Error: #{posix}"
+                Logger.warn msg
+                {:error, msg}
+            end
+          _ ->
+            msg = "Cannot make #{Path.dirname(file)}"
+            Logger.warn msg
+            {:error, msg}
+         end
+      _ ->
+        msg = "Cannot Fetch from #{api_config.discoveryRestUrl}"
+        Logger.warn msg
+        {:error, msg}
     end
   end
+
+
 
   def convert_spec(api_config = %ApiConfig{}) do
     converter = Application.get_env(:google_apis, :spec_converter)

--- a/lib/google_apis/api_config.ex
+++ b/lib/google_apis/api_config.ex
@@ -14,7 +14,7 @@
 
 defmodule GoogleApis.ApiConfig do
 
-  defstruct [:name, :version, :url]
+  defstruct [:name, :version, :url, :discoveryRestUrl]
 
   def file(%{name: name, version: version}), do: "#{name}-#{version}.json"
 

--- a/lib/google_apis/discovery.ex
+++ b/lib/google_apis/discovery.ex
@@ -21,7 +21,7 @@ defmodule GoogleApis.Discovery do
         try_formats(base, query, ["GOOGLE_REST_SIMPLE_URI", format])
       nil ->
         {:ok, body} = fetch_direct(url)
-        {:ok, {body, "default"}}
+        {:ok, body}
     end
   end
 


### PR DESCRIPTION
The code had problems at every stage:

### Fetching stage

During fetching, it wasn't writing anything to the directory, because it was [trying to write a keymap](https://github.com/GoogleCloudPlatform/elixir-google-api/compare/master...iamwilhelm:fix_spec_writing#diff-42bfcde2e73cb082f2e2267e81e7c7e9L24) to file, instead of a string.

Also, the key for the spec listings in the discovery file changed from `url` to `discoveryRestUrl`.

I changed the `with` statements to `case`, just so I could get it working, and I understood it. Uglier, but it works.

### Conversion stage

Similar problem as fetching, but it wasn't writing, because the directory `openapi` had never been created

### Build stage

Just had to state what the current docker image should be.

However, had a question here...once I generated the client, it had all these new empty files that were generated. Is that suppose to happen?