### PR TITLE
Reserved expansion and update Datastore client

### DIFF
--- a/clients/datastore/lib/google_api/datastore/v1/api/projects.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/api/projects.ex
@@ -74,7 +74,9 @@ defmodule GoogleApi.Datastore.V1.Api.Projects do
     }
     %{}
     |> method(:post)
-    |> url("/v1/projects/#{project_id}:allocateIds")
+    |> url("/v1/projects/{projectId}:allocateIds", %{
+         "projectId" => URI.encode_www_form(project_id)
+       })
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
@@ -129,7 +131,9 @@ defmodule GoogleApi.Datastore.V1.Api.Projects do
     }
     %{}
     |> method(:post)
-    |> url("/v1/projects/#{project_id}:beginTransaction")
+    |> url("/v1/projects/{projectId}:beginTransaction", %{
+         "projectId" => URI.encode_www_form(project_id)
+       })
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
@@ -184,7 +188,9 @@ defmodule GoogleApi.Datastore.V1.Api.Projects do
     }
     %{}
     |> method(:post)
-    |> url("/v1/projects/#{project_id}:commit")
+    |> url("/v1/projects/{projectId}:commit", %{
+         "projectId" => URI.encode_www_form(project_id)
+       })
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
@@ -239,7 +245,9 @@ defmodule GoogleApi.Datastore.V1.Api.Projects do
     }
     %{}
     |> method(:post)
-    |> url("/v1/projects/#{project_id}:lookup")
+    |> url("/v1/projects/{projectId}:lookup", %{
+         "projectId" => URI.encode_www_form(project_id)
+       })
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
@@ -292,7 +300,9 @@ defmodule GoogleApi.Datastore.V1.Api.Projects do
     }
     %{}
     |> method(:post)
-    |> url("/v1/#{name}:cancel")
+    |> url("/v1/{+name}:cancel", %{
+         "name" => URI.encode_www_form(name)
+       })
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
@@ -345,7 +355,9 @@ defmodule GoogleApi.Datastore.V1.Api.Projects do
     }
     %{}
     |> method(:delete)
-    |> url("/v1/#{name}")
+    |> url("/v1/{+name}", %{
+         "name" => URI.encode_www_form(name)
+       })
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
@@ -398,7 +410,9 @@ defmodule GoogleApi.Datastore.V1.Api.Projects do
     }
     %{}
     |> method(:get)
-    |> url("/v1/#{name}")
+    |> url("/v1/{+name}", %{
+         "name" => URI.encode_www_form(name)
+       })
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
@@ -457,7 +471,9 @@ defmodule GoogleApi.Datastore.V1.Api.Projects do
     }
     %{}
     |> method(:get)
-    |> url("/v1/#{name}/operations")
+    |> url("/v1/{+name}/operations", %{
+         "name" => URI.encode_www_form(name)
+       })
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
@@ -512,7 +528,9 @@ defmodule GoogleApi.Datastore.V1.Api.Projects do
     }
     %{}
     |> method(:post)
-    |> url("/v1/projects/#{project_id}:rollback")
+    |> url("/v1/projects/{projectId}:rollback", %{
+         "projectId" => URI.encode_www_form(project_id)
+       })
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
@@ -567,7 +585,9 @@ defmodule GoogleApi.Datastore.V1.Api.Projects do
     }
     %{}
     |> method(:post)
-    |> url("/v1/projects/#{project_id}:runQuery")
+    |> url("/v1/projects/{projectId}:runQuery", %{
+         "projectId" => URI.encode_www_form(project_id)
+       })
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()

--- a/clients/datastore/lib/google_api/datastore/v1/deserializer.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/deserializer.ex
@@ -46,4 +46,12 @@ defmodule GoogleApi.Datastore.V1.Deserializer do
         model
     end
   end
+
+  def serialize_non_nil(model, options) do
+    model
+    |> Map.from_struct
+    |> Enum.filter(fn {_k, v} -> v != nil end)
+    |> Enum.into(%{})
+    |> Poison.Encoder.encode(options)
+  end
 end

--- a/clients/datastore/lib/google_api/datastore/v1/model/allocate_ids_request.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/allocate_ids_request.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Datastore.V1.Model.AllocateIdsRequest do
   @moduledoc """
   The request for Datastore.AllocateIds.
+
+  ## Attributes
+
+  - keys (List[Key]): A list of keys with incomplete key paths for which to allocate IDs. No key may be reserved/read-only. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"keys"
   ]
@@ -33,6 +36,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.AllocateIdsRequest do
   def decode(value, options) do
     value
     |> deserialize(:"keys", :list, GoogleApi.Datastore.V1.Model.Key, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.AllocateIdsRequest do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/allocate_ids_response.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/allocate_ids_response.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Datastore.V1.Model.AllocateIdsResponse do
   @moduledoc """
   The response for Datastore.AllocateIds.
+
+  ## Attributes
+
+  - keys (List[Key]): The keys specified in the request (in the same order), each with its key path completed with a newly allocated ID. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"keys"
   ]
@@ -33,6 +36,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.AllocateIdsResponse do
   def decode(value, options) do
     value
     |> deserialize(:"keys", :list, GoogleApi.Datastore.V1.Model.Key, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.AllocateIdsResponse do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/array_value.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/array_value.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Datastore.V1.Model.ArrayValue do
   @moduledoc """
   An array value.
+
+  ## Attributes
+
+  - values (List[Value]): Values in the array. The order of this array may not be preserved if it contains a mix of indexed and unindexed values. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"values"
   ]
@@ -33,6 +36,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.ArrayValue do
   def decode(value, options) do
     value
     |> deserialize(:"values", :list, GoogleApi.Datastore.V1.Model.Value, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.ArrayValue do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/begin_transaction_request.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/begin_transaction_request.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Datastore.V1.Model.BeginTransactionRequest do
   @moduledoc """
   The request for Datastore.BeginTransaction.
+
+  ## Attributes
+
+  - transactionOptions (TransactionOptions): Options for a new transaction. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"transactionOptions"
   ]
@@ -33,6 +36,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.BeginTransactionReques
   def decode(value, options) do
     value
     |> deserialize(:"transactionOptions", :struct, GoogleApi.Datastore.V1.Model.TransactionOptions, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.BeginTransactionRequest do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/begin_transaction_response.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/begin_transaction_response.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Datastore.V1.Model.BeginTransactionResponse do
   @moduledoc """
   The response for Datastore.BeginTransaction.
+
+  ## Attributes
+
+  - transaction (String): The transaction identifier (always present). Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"transaction"
   ]
@@ -31,6 +34,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.BeginTransactionResponse do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.BeginTransactionResponse do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/commit_request.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/commit_request.ex
@@ -20,9 +20,15 @@
 defmodule GoogleApi.Datastore.V1.Model.CommitRequest do
   @moduledoc """
   The request for Datastore.Commit.
+
+  ## Attributes
+
+  - mode (String): The type of commit to perform. Defaults to &#x60;TRANSACTIONAL&#x60;. Defaults to: `null`.
+    - Enum - one of [MODE_UNSPECIFIED, TRANSACTIONAL, NON_TRANSACTIONAL]
+  - mutations (List[Mutation]): The mutations to perform.  When mode is &#x60;TRANSACTIONAL&#x60;, mutations affecting a single entity are applied in order. The following sequences of mutations affecting a single entity are not permitted in a single &#x60;Commit&#x60; request:  - &#x60;insert&#x60; followed by &#x60;insert&#x60; - &#x60;update&#x60; followed by &#x60;insert&#x60; - &#x60;upsert&#x60; followed by &#x60;insert&#x60; - &#x60;delete&#x60; followed by &#x60;update&#x60;  When mode is &#x60;NON_TRANSACTIONAL&#x60;, no two mutations may affect a single entity. Defaults to: `null`.
+  - transaction (String): The identifier of the transaction associated with the commit. A transaction identifier is returned by a call to Datastore.BeginTransaction. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"mode",
     :"mutations",
@@ -35,6 +41,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.CommitRequest do
   def decode(value, options) do
     value
     |> deserialize(:"mutations", :list, GoogleApi.Datastore.V1.Model.Mutation, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.CommitRequest do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/commit_response.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/commit_response.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.CommitResponse do
   @moduledoc """
   The response for Datastore.Commit.
+
+  ## Attributes
+
+  - indexUpdates (Integer): The number of index entries updated during the commit, or zero if none were updated. Defaults to: `null`.
+  - mutationResults (List[MutationResult]): The result of performing the mutations. The i-th mutation result corresponds to the i-th mutation in the request. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"indexUpdates",
     :"mutationResults"
@@ -34,6 +38,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.CommitResponse do
   def decode(value, options) do
     value
     |> deserialize(:"mutationResults", :list, GoogleApi.Datastore.V1.Model.MutationResult, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.CommitResponse do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/composite_filter.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/composite_filter.ex
@@ -20,9 +20,14 @@
 defmodule GoogleApi.Datastore.V1.Model.CompositeFilter do
   @moduledoc """
   A filter that merges multiple other filters using the given operator.
+
+  ## Attributes
+
+  - filters (List[Filter]): The list of filters to combine. Must contain at least one filter. Defaults to: `null`.
+  - op (String): The operator for combining multiple filters. Defaults to: `null`.
+    - Enum - one of [OPERATOR_UNSPECIFIED, AND]
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"filters",
     :"op"
@@ -34,6 +39,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.CompositeFilter do
   def decode(value, options) do
     value
     |> deserialize(:"filters", :list, GoogleApi.Datastore.V1.Model.Filter, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.CompositeFilter do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/empty.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/empty.ex
@@ -20,9 +20,11 @@
 defmodule GoogleApi.Datastore.V1.Model.Empty do
   @moduledoc """
   A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance:      service Foo {       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);     }  The JSON representation for &#x60;Empty&#x60; is empty JSON object &#x60;{}&#x60;.
+
+  ## Attributes
+
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     
   ]
@@ -31,6 +33,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.Empty do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.Empty do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/entity.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/entity.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.Entity do
   @moduledoc """
   A Datastore data object.  An entity is limited to 1 megabyte when stored. That _roughly_ corresponds to a limit of 1 megabyte for the serialized form of this message.
+
+  ## Attributes
+
+  - key (Key): The entity&#39;s key.  An entity must have a key, unless otherwise documented (for example, an entity in &#x60;Value.entity_value&#x60; may have no key). An entity&#39;s kind is its key path&#39;s last element&#39;s kind, or null if it has no key. Defaults to: `null`.
+  - properties (Map[String, Value]): The entity&#39;s properties. The map&#39;s keys are property names. A property name matching regex &#x60;__.*__&#x60; is reserved. A reserved property name is forbidden in certain documented contexts. The name must not contain more than 500 characters. The name cannot be &#x60;\&quot;\&quot;&#x60;. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"key",
     :"properties"
@@ -35,6 +39,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.Entity do
     value
     |> deserialize(:"key", :struct, GoogleApi.Datastore.V1.Model.Key, options)
     |> deserialize(:"properties", :map, GoogleApi.Datastore.V1.Model.Value, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.Entity do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/entity_result.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/entity_result.ex
@@ -20,9 +20,14 @@
 defmodule GoogleApi.Datastore.V1.Model.EntityResult do
   @moduledoc """
   The result of fetching an entity from Datastore.
+
+  ## Attributes
+
+  - cursor (String): A cursor that points to the position after the result entity. Set only when the &#x60;EntityResult&#x60; is part of a &#x60;QueryResultBatch&#x60; message. Defaults to: `null`.
+  - entity (Entity): The resulting entity. Defaults to: `null`.
+  - version (String): The version of the entity, a strictly positive number that monotonically increases with changes to the entity.  This field is set for &#x60;FULL&#x60; entity results.  For missing entities in &#x60;LookupResponse&#x60;, this is the version of the snapshot that was used to look up the entity, and it is always set except for eventually consistent reads. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"cursor",
     :"entity",
@@ -35,6 +40,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.EntityResult do
   def decode(value, options) do
     value
     |> deserialize(:"entity", :struct, GoogleApi.Datastore.V1.Model.Entity, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.EntityResult do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/filter.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/filter.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.Filter do
   @moduledoc """
   A holder for any type of filter.
+
+  ## Attributes
+
+  - compositeFilter (CompositeFilter): A composite filter. Defaults to: `null`.
+  - propertyFilter (PropertyFilter): A filter on a property. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"compositeFilter",
     :"propertyFilter"
@@ -35,6 +39,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.Filter do
     value
     |> deserialize(:"compositeFilter", :struct, GoogleApi.Datastore.V1.Model.CompositeFilter, options)
     |> deserialize(:"propertyFilter", :struct, GoogleApi.Datastore.V1.Model.PropertyFilter, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.Filter do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/google_datastore_admin_v1beta1_common_metadata.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/google_datastore_admin_v1beta1_common_metadata.ex
@@ -20,9 +20,18 @@
 defmodule GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1CommonMetadata do
   @moduledoc """
   Metadata common to all Datastore Admin operations.
+
+  ## Attributes
+
+  - endTime (String): The time the operation ended, either successfully or otherwise. Defaults to: `null`.
+  - labels (Map[String, String]): The client-assigned labels which were provided when the operation was created.  May also include additional labels. Defaults to: `null`.
+  - operationType (String): The type of the operation.  Can be used as a filter in ListOperationsRequest. Defaults to: `null`.
+    - Enum - one of [OPERATION_TYPE_UNSPECIFIED, EXPORT_ENTITIES, IMPORT_ENTITIES, BUILD_INDEX, CLEAR_INDEX]
+  - startTime (String): The time that work began on the operation. Defaults to: `null`.
+  - state (String): The current state of the Operation. Defaults to: `null`.
+    - Enum - one of [STATE_UNSPECIFIED, INITIALIZING, PROCESSING, CANCELLING, FINALIZING, SUCCESSFUL, FAILED, CANCELLED]
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"endTime",
     :"labels",
@@ -35,6 +44,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1CommonMetadata do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1CommonMetadata do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/google_datastore_admin_v1beta1_entity_filter.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/google_datastore_admin_v1beta1_entity_filter.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1EntityFilter do
   @moduledoc """
   Identifies a subset of entities in a project.  This is specified as combinations of kind + namespace (either or both of which may be all, as described in the following examples). Example usage:  Entire project:   kinds&#x3D;[], namespace_ids&#x3D;[]  Kinds Foo and Bar in all namespaces:   kinds&#x3D;[&#39;Foo&#39;, &#39;Bar&#39;], namespace_ids&#x3D;[]  Kinds Foo and Bar only in the default namespace:   kinds&#x3D;[&#39;Foo&#39;, &#39;Bar&#39;], namespace_ids&#x3D;[&#39;&#39;]  Kinds Foo and Bar in both the default and Baz namespaces:   kinds&#x3D;[&#39;Foo&#39;, &#39;Bar&#39;], namespace_ids&#x3D;[&#39;&#39;, &#39;Baz&#39;]  The entire Baz namespace:   kinds&#x3D;[], namespace_ids&#x3D;[&#39;Baz&#39;]
+
+  ## Attributes
+
+  - kinds (List[String]): If empty, then this represents all kinds. Defaults to: `null`.
+  - namespaceIds (List[String]): An empty list represents all namespaces.  This is the preferred usage for projects that don&#39;t use namespaces.  An empty string element represents the default namespace.  This should be used if the project has data in non-default namespaces, but doesn&#39;t want to include them. Each namespace in this list must be unique. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"kinds",
     :"namespaceIds"
@@ -32,6 +36,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1EntityFilter do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1EntityFilter do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/google_datastore_admin_v1beta1_export_entities_metadata.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/google_datastore_admin_v1beta1_export_entities_metadata.ex
@@ -20,9 +20,16 @@
 defmodule GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1ExportEntitiesMetadata do
   @moduledoc """
   Metadata for ExportEntities operations.
+
+  ## Attributes
+
+  - common (GoogleDatastoreAdminV1beta1CommonMetadata): Metadata common to all Datastore Admin operations. Defaults to: `null`.
+  - entityFilter (GoogleDatastoreAdminV1beta1EntityFilter): Description of which entities are being exported. Defaults to: `null`.
+  - outputUrlPrefix (String): Location for the export metadata and data files. This will be the same value as the google.datastore.admin.v1beta1.ExportEntitiesRequest.output_url_prefix field. The final output location is provided in google.datastore.admin.v1beta1.ExportEntitiesResponse.output_url. Defaults to: `null`.
+  - progressBytes (GoogleDatastoreAdminV1beta1Progress): An estimate of the number of bytes processed. Defaults to: `null`.
+  - progressEntities (GoogleDatastoreAdminV1beta1Progress): An estimate of the number of entities processed. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"common",
     :"entityFilter",
@@ -40,6 +47,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1
     |> deserialize(:"entityFilter", :struct, GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1EntityFilter, options)
     |> deserialize(:"progressBytes", :struct, GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1Progress, options)
     |> deserialize(:"progressEntities", :struct, GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1Progress, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1ExportEntitiesMetadata do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/google_datastore_admin_v1beta1_export_entities_response.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/google_datastore_admin_v1beta1_export_entities_response.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1ExportEntitiesResponse do
   @moduledoc """
   The response for google.datastore.admin.v1beta1.DatastoreAdmin.ExportEntities.
+
+  ## Attributes
+
+  - outputUrl (String): Location of the output metadata file. This can be used to begin an import into Cloud Datastore (this project or another project). See google.datastore.admin.v1beta1.ImportEntitiesRequest.input_url. Only present if the operation completed successfully. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"outputUrl"
   ]
@@ -31,6 +34,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1ExportEntitiesResponse do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1ExportEntitiesResponse do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/google_datastore_admin_v1beta1_import_entities_metadata.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/google_datastore_admin_v1beta1_import_entities_metadata.ex
@@ -20,9 +20,16 @@
 defmodule GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1ImportEntitiesMetadata do
   @moduledoc """
   Metadata for ImportEntities operations.
+
+  ## Attributes
+
+  - common (GoogleDatastoreAdminV1beta1CommonMetadata): Metadata common to all Datastore Admin operations. Defaults to: `null`.
+  - entityFilter (GoogleDatastoreAdminV1beta1EntityFilter): Description of which entities are being imported. Defaults to: `null`.
+  - inputUrl (String): The location of the import metadata file. This will be the same value as the google.datastore.admin.v1beta1.ExportEntitiesResponse.output_url field. Defaults to: `null`.
+  - progressBytes (GoogleDatastoreAdminV1beta1Progress): An estimate of the number of bytes processed. Defaults to: `null`.
+  - progressEntities (GoogleDatastoreAdminV1beta1Progress): An estimate of the number of entities processed. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"common",
     :"entityFilter",
@@ -40,6 +47,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1
     |> deserialize(:"entityFilter", :struct, GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1EntityFilter, options)
     |> deserialize(:"progressBytes", :struct, GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1Progress, options)
     |> deserialize(:"progressEntities", :struct, GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1Progress, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1ImportEntitiesMetadata do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/google_datastore_admin_v1beta1_progress.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/google_datastore_admin_v1beta1_progress.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1Progress do
   @moduledoc """
   Measures the progress of a particular metric.
+
+  ## Attributes
+
+  - workCompleted (String): Note that this may be greater than work_estimated. Defaults to: `null`.
+  - workEstimated (String): An estimate of how much work needs to be performed.  May be zero if the work estimate is unavailable. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"workCompleted",
     :"workEstimated"
@@ -32,6 +36,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1Progress do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.GoogleDatastoreAdminV1beta1Progress do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/google_longrunning_list_operations_response.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/google_longrunning_list_operations_response.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.GoogleLongrunningListOperationsResponse do
   @moduledoc """
   The response message for Operations.ListOperations.
+
+  ## Attributes
+
+  - nextPageToken (String): The standard List next-page token. Defaults to: `null`.
+  - operations (List[GoogleLongrunningOperation]): A list of operations that matches the specified filter in the request. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"nextPageToken",
     :"operations"
@@ -34,6 +38,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.GoogleLongrunningListO
   def decode(value, options) do
     value
     |> deserialize(:"operations", :list, GoogleApi.Datastore.V1.Model.GoogleLongrunningOperation, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.GoogleLongrunningListOperationsResponse do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/google_longrunning_operation.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/google_longrunning_operation.ex
@@ -20,9 +20,16 @@
 defmodule GoogleApi.Datastore.V1.Model.GoogleLongrunningOperation do
   @moduledoc """
   This resource represents a long-running operation that is the result of a network API call.
+
+  ## Attributes
+
+  - done (Boolean): If the value is &#x60;false&#x60;, it means the operation is still in progress. If true, the operation is completed, and either &#x60;error&#x60; or &#x60;response&#x60; is available. Defaults to: `null`.
+  - error (Status): The error result of the operation in case of failure or cancellation. Defaults to: `null`.
+  - metadata (Object): Service-specific metadata associated with the operation.  It typically contains progress information and common metadata such as create time. Some services might not provide such metadata.  Any method that returns a long-running operation should document the metadata type, if any. Defaults to: `null`.
+  - name (String): The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the &#x60;name&#x60; should have the format of &#x60;operations/some/unique/name&#x60;. Defaults to: `null`.
+  - response (Object): The normal response of the operation in case of success.  If the original method returns no data on success, such as &#x60;Delete&#x60;, the response is &#x60;google.protobuf.Empty&#x60;.  If the original method is standard &#x60;Get&#x60;/&#x60;Create&#x60;/&#x60;Update&#x60;, the response should be the resource.  For other methods, the response should have the type &#x60;XxxResponse&#x60;, where &#x60;Xxx&#x60; is the original method name.  For example, if the original method name is &#x60;TakeSnapshot()&#x60;, the inferred response type is &#x60;TakeSnapshotResponse&#x60;. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"done",
     :"error",
@@ -39,6 +46,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.GoogleLongrunningOpera
     |> deserialize(:"error", :struct, GoogleApi.Datastore.V1.Model.Status, options)
     |> deserialize(:"metadata", :struct, GoogleApi.Datastore.V1.Model.Object, options)
     |> deserialize(:"response", :struct, GoogleApi.Datastore.V1.Model.Object, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.GoogleLongrunningOperation do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/gql_query.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/gql_query.ex
@@ -20,9 +20,15 @@
 defmodule GoogleApi.Datastore.V1.Model.GqlQuery do
   @moduledoc """
   A [GQL query](https://cloud.google.com/datastore/docs/apis/gql/gql_reference).
+
+  ## Attributes
+
+  - allowLiterals (Boolean): When false, the query string must not contain any literals and instead must bind all values. For example, &#x60;SELECT * FROM Kind WHERE a &#x3D; &#39;string literal&#39;&#x60; is not allowed, while &#x60;SELECT * FROM Kind WHERE a &#x3D; @value&#x60; is. Defaults to: `null`.
+  - namedBindings (Map[String, GqlQueryParameter]): For each non-reserved named binding site in the query string, there must be a named parameter with that name, but not necessarily the inverse.  Key must match regex &#x60;A-Za-z_$*&#x60;, must not match regex &#x60;__.*__&#x60;, and must not be &#x60;\&quot;\&quot;&#x60;. Defaults to: `null`.
+  - positionalBindings (List[GqlQueryParameter]): Numbered binding site @1 references the first numbered parameter, effectively using 1-based indexing, rather than the usual 0.  For each binding site numbered i in &#x60;query_string&#x60;, there must be an i-th numbered parameter. The inverse must also be true. Defaults to: `null`.
+  - queryString (String): A string of the format described [here](https://cloud.google.com/datastore/docs/apis/gql/gql_reference). Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"allowLiterals",
     :"namedBindings",
@@ -37,6 +43,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.GqlQuery do
     value
     |> deserialize(:"namedBindings", :map, GoogleApi.Datastore.V1.Model.GqlQueryParameter, options)
     |> deserialize(:"positionalBindings", :list, GoogleApi.Datastore.V1.Model.GqlQueryParameter, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.GqlQuery do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/gql_query_parameter.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/gql_query_parameter.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.GqlQueryParameter do
   @moduledoc """
   A binding parameter for a GQL query.
+
+  ## Attributes
+
+  - cursor (String): A query cursor. Query cursors are returned in query result batches. Defaults to: `null`.
+  - value (Value): A value parameter. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"cursor",
     :"value"
@@ -34,6 +38,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.GqlQueryParameter do
   def decode(value, options) do
     value
     |> deserialize(:"value", :struct, GoogleApi.Datastore.V1.Model.Value, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.GqlQueryParameter do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/key.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/key.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.Key do
   @moduledoc """
   A unique identifier for an entity. If a key&#39;s partition ID or any of its path kinds or names are reserved/read-only, the key is reserved/read-only. A reserved/read-only key is forbidden in certain documented contexts.
+
+  ## Attributes
+
+  - partitionId (PartitionId): Entities are partitioned into subsets, currently identified by a project ID and namespace ID. Queries are scoped to a single partition. Defaults to: `null`.
+  - path (List[PathElement]): The entity path. An entity path consists of one or more elements composed of a kind and a string or numerical identifier, which identify entities. The first element identifies a _root entity_, the second element identifies a _child_ of the root entity, the third element identifies a child of the second entity, and so forth. The entities identified by all prefixes of the path are called the element&#39;s _ancestors_.  An entity path is always fully complete: *all* of the entity&#39;s ancestors are required to be in the path along with the entity identifier itself. The only exception is that in some documented cases, the identifier in the last path element (for the entity) itself may be omitted. For example, the last path element of the key of &#x60;Mutation.insert&#x60; may have no identifier.  A path can never be empty, and a path can have at most 100 elements. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"partitionId",
     :"path"
@@ -35,6 +39,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.Key do
     value
     |> deserialize(:"partitionId", :struct, GoogleApi.Datastore.V1.Model.PartitionId, options)
     |> deserialize(:"path", :list, GoogleApi.Datastore.V1.Model.PathElement, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.Key do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/kind_expression.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/kind_expression.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Datastore.V1.Model.KindExpression do
   @moduledoc """
   A representation of a kind.
+
+  ## Attributes
+
+  - name (String): The name of the kind. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"name"
   ]
@@ -31,6 +34,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.KindExpression do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.KindExpression do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/lat_lng.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/lat_lng.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.LatLng do
   @moduledoc """
   An object representing a latitude/longitude pair. This is expressed as a pair of doubles representing degrees latitude and degrees longitude. Unless specified otherwise, this must conform to the &lt;a href&#x3D;\&quot;http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf\&quot;&gt;WGS84 standard&lt;/a&gt;. Values must be within normalized ranges.  Example of normalization code in Python:      def NormalizeLongitude(longitude):       \&quot;\&quot;\&quot;Wraps decimal degrees longitude to [-180.0, 180.0].\&quot;\&quot;\&quot;       q, r &#x3D; divmod(longitude, 360.0)       if r &gt; 180.0 or (r &#x3D;&#x3D; 180.0 and q &lt;&#x3D; -1.0):         return r - 360.0       return r      def NormalizeLatLng(latitude, longitude):       \&quot;\&quot;\&quot;Wraps decimal degrees latitude and longitude to       [-90.0, 90.0] and [-180.0, 180.0], respectively.\&quot;\&quot;\&quot;       r &#x3D; latitude % 360.0       if r &lt;&#x3D; 90.0:         return r, NormalizeLongitude(longitude)       elif r &gt;&#x3D; 270.0:         return r - 360, NormalizeLongitude(longitude)       else:         return 180 - r, NormalizeLongitude(longitude + 180.0)      assert 180.0 &#x3D;&#x3D; NormalizeLongitude(180.0)     assert -180.0 &#x3D;&#x3D; NormalizeLongitude(-180.0)     assert -179.0 &#x3D;&#x3D; NormalizeLongitude(181.0)     assert (0.0, 0.0) &#x3D;&#x3D; NormalizeLatLng(360.0, 0.0)     assert (0.0, 0.0) &#x3D;&#x3D; NormalizeLatLng(-360.0, 0.0)     assert (85.0, 180.0) &#x3D;&#x3D; NormalizeLatLng(95.0, 0.0)     assert (-85.0, -170.0) &#x3D;&#x3D; NormalizeLatLng(-95.0, 10.0)     assert (90.0, 10.0) &#x3D;&#x3D; NormalizeLatLng(90.0, 10.0)     assert (-90.0, -10.0) &#x3D;&#x3D; NormalizeLatLng(-90.0, -10.0)     assert (0.0, -170.0) &#x3D;&#x3D; NormalizeLatLng(-180.0, 10.0)     assert (0.0, -170.0) &#x3D;&#x3D; NormalizeLatLng(180.0, 10.0)     assert (-90.0, 10.0) &#x3D;&#x3D; NormalizeLatLng(270.0, 10.0)     assert (90.0, 10.0) &#x3D;&#x3D; NormalizeLatLng(-270.0, 10.0)
+
+  ## Attributes
+
+  - latitude (Float): The latitude in degrees. It must be in the range [-90.0, +90.0]. Defaults to: `null`.
+  - longitude (Float): The longitude in degrees. It must be in the range [-180.0, +180.0]. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"latitude",
     :"longitude"
@@ -32,6 +36,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.LatLng do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.LatLng do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/lookup_request.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/lookup_request.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.LookupRequest do
   @moduledoc """
   The request for Datastore.Lookup.
+
+  ## Attributes
+
+  - keys (List[Key]): Keys of entities to look up. Defaults to: `null`.
+  - readOptions (ReadOptions): The options for this lookup request. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"keys",
     :"readOptions"
@@ -35,6 +39,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.LookupRequest do
     value
     |> deserialize(:"keys", :list, GoogleApi.Datastore.V1.Model.Key, options)
     |> deserialize(:"readOptions", :struct, GoogleApi.Datastore.V1.Model.ReadOptions, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.LookupRequest do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/lookup_response.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/lookup_response.ex
@@ -20,9 +20,14 @@
 defmodule GoogleApi.Datastore.V1.Model.LookupResponse do
   @moduledoc """
   The response for Datastore.Lookup.
+
+  ## Attributes
+
+  - deferred (List[Key]): A list of keys that were not looked up due to resource constraints. The order of results in this field is undefined and has no relation to the order of the keys in the input. Defaults to: `null`.
+  - found (List[EntityResult]): Entities found as &#x60;ResultType.FULL&#x60; entities. The order of results in this field is undefined and has no relation to the order of the keys in the input. Defaults to: `null`.
+  - missing (List[EntityResult]): Entities not found as &#x60;ResultType.KEY_ONLY&#x60; entities. The order of results in this field is undefined and has no relation to the order of the keys in the input. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"deferred",
     :"found",
@@ -37,6 +42,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.LookupResponse do
     |> deserialize(:"deferred", :list, GoogleApi.Datastore.V1.Model.Key, options)
     |> deserialize(:"found", :list, GoogleApi.Datastore.V1.Model.EntityResult, options)
     |> deserialize(:"missing", :list, GoogleApi.Datastore.V1.Model.EntityResult, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.LookupResponse do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/mutation.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/mutation.ex
@@ -20,9 +20,16 @@
 defmodule GoogleApi.Datastore.V1.Model.Mutation do
   @moduledoc """
   A mutation to apply to an entity.
+
+  ## Attributes
+
+  - baseVersion (String): The version of the entity that this mutation is being applied to. If this does not match the current version on the server, the mutation conflicts. Defaults to: `null`.
+  - delete (Key): The key of the entity to delete. The entity may or may not already exist. Must have a complete key path and must not be reserved/read-only. Defaults to: `null`.
+  - insert (Entity): The entity to insert. The entity must not already exist. The entity key&#39;s final path element may be incomplete. Defaults to: `null`.
+  - update (Entity): The entity to update. The entity must already exist. Must have a complete key path. Defaults to: `null`.
+  - upsert (Entity): The entity to upsert. The entity may or may not already exist. The entity key&#39;s final path element may be incomplete. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"baseVersion",
     :"delete",
@@ -40,6 +47,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.Mutation do
     |> deserialize(:"insert", :struct, GoogleApi.Datastore.V1.Model.Entity, options)
     |> deserialize(:"update", :struct, GoogleApi.Datastore.V1.Model.Entity, options)
     |> deserialize(:"upsert", :struct, GoogleApi.Datastore.V1.Model.Entity, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.Mutation do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/mutation_result.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/mutation_result.ex
@@ -20,9 +20,14 @@
 defmodule GoogleApi.Datastore.V1.Model.MutationResult do
   @moduledoc """
   The result of applying a mutation.
+
+  ## Attributes
+
+  - conflictDetected (Boolean): Whether a conflict was detected for this mutation. Always false when a conflict detection strategy field is not set in the mutation. Defaults to: `null`.
+  - key (Key): The automatically allocated key. Set only when the mutation allocated a key. Defaults to: `null`.
+  - version (String): The version of the entity on the server after processing the mutation. If the mutation doesn&#39;t change anything on the server, then the version will be the version of the current entity or, if no entity is present, a version that is strictly greater than the version of any previous entity and less than the version of any possible future entity. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"conflictDetected",
     :"key",
@@ -35,6 +40,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.MutationResult do
   def decode(value, options) do
     value
     |> deserialize(:"key", :struct, GoogleApi.Datastore.V1.Model.Key, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.MutationResult do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/partition_id.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/partition_id.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.PartitionId do
   @moduledoc """
   A partition ID identifies a grouping of entities. The grouping is always by project and namespace, however the namespace ID may be empty.  A partition ID contains several dimensions: project ID and namespace ID.  Partition dimensions:  - May be &#x60;\&quot;\&quot;&#x60;. - Must be valid UTF-8 bytes. - Must have values that match regex &#x60;[A-Za-z\\d\\.\\-_]{1,100}&#x60; If the value of any dimension matches regex &#x60;__.*__&#x60;, the partition is reserved/read-only. A reserved/read-only partition ID is forbidden in certain documented contexts.  Foreign partition IDs (in which the project ID does not match the context project ID ) are discouraged. Reads and writes of foreign partition IDs may fail if the project is not in an active state.
+
+  ## Attributes
+
+  - namespaceId (String): If not empty, the ID of the namespace to which the entities belong. Defaults to: `null`.
+  - projectId (String): The ID of the project to which the entities belong. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"namespaceId",
     :"projectId"
@@ -32,6 +36,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.PartitionId do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.PartitionId do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/path_element.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/path_element.ex
@@ -20,9 +20,14 @@
 defmodule GoogleApi.Datastore.V1.Model.PathElement do
   @moduledoc """
   A (kind, ID/name) pair used to construct a key path.  If either name or ID is set, the element is complete. If neither is set, the element is incomplete.
+
+  ## Attributes
+
+  - id (String): The auto-allocated ID of the entity. Never equal to zero. Values less than zero are discouraged and may not be supported in the future. Defaults to: `null`.
+  - kind (String): The kind of the entity. A kind matching regex &#x60;__.*__&#x60; is reserved/read-only. A kind must not contain more than 1500 bytes when UTF-8 encoded. Cannot be &#x60;\&quot;\&quot;&#x60;. Defaults to: `null`.
+  - name (String): The name of the entity. A name matching regex &#x60;__.*__&#x60; is reserved/read-only. A name must not be more than 1500 bytes when UTF-8 encoded. Cannot be &#x60;\&quot;\&quot;&#x60;. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"id",
     :"kind",
@@ -33,6 +38,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.PathElement do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.PathElement do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/projection.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/projection.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Datastore.V1.Model.Projection do
   @moduledoc """
   A representation of a property in a projection.
+
+  ## Attributes
+
+  - property (PropertyReference): The property to project. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"property"
   ]
@@ -33,6 +36,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.Projection do
   def decode(value, options) do
     value
     |> deserialize(:"property", :struct, GoogleApi.Datastore.V1.Model.PropertyReference, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.Projection do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/property_filter.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/property_filter.ex
@@ -20,9 +20,15 @@
 defmodule GoogleApi.Datastore.V1.Model.PropertyFilter do
   @moduledoc """
   A filter on a specific property.
+
+  ## Attributes
+
+  - op (String): The operator to filter by. Defaults to: `null`.
+    - Enum - one of [OPERATOR_UNSPECIFIED, LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL, EQUAL, HAS_ANCESTOR]
+  - property (PropertyReference): The property to filter by. Defaults to: `null`.
+  - value (Value): The value to compare the property to. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"op",
     :"property",
@@ -36,6 +42,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.PropertyFilter do
     value
     |> deserialize(:"property", :struct, GoogleApi.Datastore.V1.Model.PropertyReference, options)
     |> deserialize(:"value", :struct, GoogleApi.Datastore.V1.Model.Value, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.PropertyFilter do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/property_order.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/property_order.ex
@@ -20,9 +20,14 @@
 defmodule GoogleApi.Datastore.V1.Model.PropertyOrder do
   @moduledoc """
   The desired order for a specific property.
+
+  ## Attributes
+
+  - direction (String): The direction to order by. Defaults to &#x60;ASCENDING&#x60;. Defaults to: `null`.
+    - Enum - one of [DIRECTION_UNSPECIFIED, ASCENDING, DESCENDING]
+  - property (PropertyReference): The property to order by. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"direction",
     :"property"
@@ -34,6 +39,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.PropertyOrder do
   def decode(value, options) do
     value
     |> deserialize(:"property", :struct, GoogleApi.Datastore.V1.Model.PropertyReference, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.PropertyOrder do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/property_reference.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/property_reference.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Datastore.V1.Model.PropertyReference do
   @moduledoc """
   A reference to a property relative to the kind expressions.
+
+  ## Attributes
+
+  - name (String): The name of the property. If name includes \&quot;.\&quot;s, it may be interpreted as a property name path. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"name"
   ]
@@ -31,6 +34,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.PropertyReference do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.PropertyReference do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/query.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/query.ex
@@ -20,9 +20,20 @@
 defmodule GoogleApi.Datastore.V1.Model.Query do
   @moduledoc """
   A query for entities.
+
+  ## Attributes
+
+  - distinctOn (List[PropertyReference]): The properties to make distinct. The query results will contain the first result for each distinct combination of values for the given properties (if empty, all results are returned). Defaults to: `null`.
+  - endCursor (String): An ending point for the query results. Query cursors are returned in query result batches and [can only be used to limit the same query](https://cloud.google.com/datastore/docs/concepts/queries#cursors_limits_and_offsets). Defaults to: `null`.
+  - filter (Filter): The filter to apply. Defaults to: `null`.
+  - kind (List[KindExpression]): The kinds to query (if empty, returns entities of all kinds). Currently at most 1 kind may be specified. Defaults to: `null`.
+  - limit (Integer): The maximum number of results to return. Applies after all other constraints. Optional. Unspecified is interpreted as no limit. Must be &gt;&#x3D; 0 if specified. Defaults to: `null`.
+  - offset (Integer): The number of results to skip. Applies before limit, but after all other constraints. Optional. Must be &gt;&#x3D; 0 if specified. Defaults to: `null`.
+  - order (List[PropertyOrder]): The order to apply to the query results (if empty, order is unspecified). Defaults to: `null`.
+  - projection (List[Projection]): The projection to return. Defaults to returning all properties. Defaults to: `null`.
+  - startCursor (String): A starting point for the query results. Query cursors are returned in query result batches and [can only be used to continue the same query](https://cloud.google.com/datastore/docs/concepts/queries#cursors_limits_and_offsets). Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"distinctOn",
     :"endCursor",
@@ -45,6 +56,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.Query do
     |> deserialize(:"kind", :list, GoogleApi.Datastore.V1.Model.KindExpression, options)
     |> deserialize(:"order", :list, GoogleApi.Datastore.V1.Model.PropertyOrder, options)
     |> deserialize(:"projection", :list, GoogleApi.Datastore.V1.Model.Projection, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.Query do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/query_result_batch.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/query_result_batch.ex
@@ -20,9 +20,20 @@
 defmodule GoogleApi.Datastore.V1.Model.QueryResultBatch do
   @moduledoc """
   A batch of results produced by a query.
+
+  ## Attributes
+
+  - endCursor (String): A cursor that points to the position after the last result in the batch. Defaults to: `null`.
+  - entityResultType (String): The result type for every entity in &#x60;entity_results&#x60;. Defaults to: `null`.
+    - Enum - one of [RESULT_TYPE_UNSPECIFIED, FULL, PROJECTION, KEY_ONLY]
+  - entityResults (List[EntityResult]): The results for this batch. Defaults to: `null`.
+  - moreResults (String): The state of the query after the current batch. Defaults to: `null`.
+    - Enum - one of [MORE_RESULTS_TYPE_UNSPECIFIED, NOT_FINISHED, MORE_RESULTS_AFTER_LIMIT, MORE_RESULTS_AFTER_CURSOR, NO_MORE_RESULTS]
+  - skippedCursor (String): A cursor that points to the position after the last skipped result. Will be set when &#x60;skipped_results&#x60; !&#x3D; 0. Defaults to: `null`.
+  - skippedResults (Integer): The number of results skipped, typically because of an offset. Defaults to: `null`.
+  - snapshotVersion (String): The version number of the snapshot this batch was returned from. This applies to the range of results from the query&#39;s &#x60;start_cursor&#x60; (or the beginning of the query if no cursor was given) to this batch&#39;s &#x60;end_cursor&#x60; (not the query&#39;s &#x60;end_cursor&#x60;).  In a single transaction, subsequent query result batches for the same query can have a greater snapshot version number. Each batch&#39;s snapshot version is valid for all preceding batches. The value will be zero for eventually consistent queries. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"endCursor",
     :"entityResultType",
@@ -39,6 +50,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.QueryResultBatch do
   def decode(value, options) do
     value
     |> deserialize(:"entityResults", :list, GoogleApi.Datastore.V1.Model.EntityResult, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.QueryResultBatch do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/read_only.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/read_only.ex
@@ -20,9 +20,11 @@
 defmodule GoogleApi.Datastore.V1.Model.ReadOnly do
   @moduledoc """
   Options specific to read-only transactions.
+
+  ## Attributes
+
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     
   ]
@@ -31,6 +33,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.ReadOnly do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.ReadOnly do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/read_options.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/read_options.ex
@@ -20,9 +20,14 @@
 defmodule GoogleApi.Datastore.V1.Model.ReadOptions do
   @moduledoc """
   The options shared by read requests.
+
+  ## Attributes
+
+  - readConsistency (String): The non-transactional read consistency to use. Cannot be set to &#x60;STRONG&#x60; for global queries. Defaults to: `null`.
+    - Enum - one of [READ_CONSISTENCY_UNSPECIFIED, STRONG, EVENTUAL]
+  - transaction (String): The identifier of the transaction in which to read. A transaction identifier is returned by a call to Datastore.BeginTransaction. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"readConsistency",
     :"transaction"
@@ -32,6 +37,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.ReadOptions do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.ReadOptions do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/read_write.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/read_write.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Datastore.V1.Model.ReadWrite do
   @moduledoc """
   Options specific to read / write transactions.
+
+  ## Attributes
+
+  - previousTransaction (String): The transaction identifier of the transaction being retried. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"previousTransaction"
   ]
@@ -31,6 +34,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.ReadWrite do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.ReadWrite do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/rollback_request.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/rollback_request.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Datastore.V1.Model.RollbackRequest do
   @moduledoc """
   The request for Datastore.Rollback.
+
+  ## Attributes
+
+  - transaction (String): The transaction identifier, returned by a call to Datastore.BeginTransaction. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"transaction"
   ]
@@ -31,6 +34,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.RollbackRequest do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.RollbackRequest do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/rollback_response.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/rollback_response.ex
@@ -20,9 +20,11 @@
 defmodule GoogleApi.Datastore.V1.Model.RollbackResponse do
   @moduledoc """
   The response for Datastore.Rollback. (an empty message).
+
+  ## Attributes
+
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     
   ]
@@ -31,6 +33,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.RollbackResponse do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.RollbackResponse do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/run_query_request.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/run_query_request.ex
@@ -20,9 +20,15 @@
 defmodule GoogleApi.Datastore.V1.Model.RunQueryRequest do
   @moduledoc """
   The request for Datastore.RunQuery.
+
+  ## Attributes
+
+  - gqlQuery (GqlQuery): The GQL query to run. Defaults to: `null`.
+  - partitionId (PartitionId): Entities are partitioned into subsets, identified by a partition ID. Queries are scoped to a single partition. This partition ID is normalized with the standard default context partition ID. Defaults to: `null`.
+  - query (Query): The query to run. Defaults to: `null`.
+  - readOptions (ReadOptions): The options for this query. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"gqlQuery",
     :"partitionId",
@@ -39,6 +45,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.RunQueryRequest do
     |> deserialize(:"partitionId", :struct, GoogleApi.Datastore.V1.Model.PartitionId, options)
     |> deserialize(:"query", :struct, GoogleApi.Datastore.V1.Model.Query, options)
     |> deserialize(:"readOptions", :struct, GoogleApi.Datastore.V1.Model.ReadOptions, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.RunQueryRequest do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/run_query_response.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/run_query_response.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.RunQueryResponse do
   @moduledoc """
   The response for Datastore.RunQuery.
+
+  ## Attributes
+
+  - batch (QueryResultBatch): A batch of query results (always present). Defaults to: `null`.
+  - query (Query): The parsed form of the &#x60;GqlQuery&#x60; from the request, if it was set. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"batch",
     :"query"
@@ -35,6 +39,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.RunQueryResponse do
     value
     |> deserialize(:"batch", :struct, GoogleApi.Datastore.V1.Model.QueryResultBatch, options)
     |> deserialize(:"query", :struct, GoogleApi.Datastore.V1.Model.Query, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.RunQueryResponse do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/status.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/status.ex
@@ -20,9 +20,14 @@
 defmodule GoogleApi.Datastore.V1.Model.Status do
   @moduledoc """
   The &#x60;Status&#x60; type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). The error model is designed to be:  - Simple to use and understand for most users - Flexible enough to meet unexpected needs  # Overview  The &#x60;Status&#x60; message contains three pieces of data: error code, error message, and error details. The error code should be an enum value of google.rpc.Code, but it may accept additional error codes if needed.  The error message should be a developer-facing English message that helps developers *understand* and *resolve* the error. If a localized user-facing error message is needed, put the localized message in the error details or localize it in the client. The optional error details may contain arbitrary information about the error. There is a predefined set of error detail types in the package &#x60;google.rpc&#x60; that can be used for common error conditions.  # Language mapping  The &#x60;Status&#x60; message is the logical representation of the error model, but it is not necessarily the actual wire format. When the &#x60;Status&#x60; message is exposed in different client libraries and different wire protocols, it can be mapped differently. For example, it will likely be mapped to some exceptions in Java, but more likely mapped to some error codes in C.  # Other uses  The error model and the &#x60;Status&#x60; message can be used in a variety of environments, either with or without APIs, to provide a consistent developer experience across different environments.  Example uses of this error model include:  - Partial errors. If a service needs to return partial errors to the client,     it may embed the &#x60;Status&#x60; in the normal response to indicate the partial     errors.  - Workflow errors. A typical workflow has multiple steps. Each step may     have a &#x60;Status&#x60; message for error reporting.  - Batch operations. If a client uses batch request and batch response, the     &#x60;Status&#x60; message should be used directly inside batch response, one for     each error sub-response.  - Asynchronous operations. If an API call embeds asynchronous operation     results in its response, the status of those operations should be     represented directly using the &#x60;Status&#x60; message.  - Logging. If some API errors are stored in logs, the message &#x60;Status&#x60; could     be used directly after any stripping needed for security/privacy reasons.
+
+  ## Attributes
+
+  - code (Integer): The status code, which should be an enum value of google.rpc.Code. Defaults to: `null`.
+  - details (List[Object]): A list of messages that carry the error details.  There is a common set of message types for APIs to use. Defaults to: `null`.
+  - message (String): A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"code",
     :"details",
@@ -35,6 +40,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.Status do
   def decode(value, options) do
     value
     |> deserialize(:"details", :list, GoogleApi.Datastore.V1.Model.Object, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.Status do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/transaction_options.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/transaction_options.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Datastore.V1.Model.TransactionOptions do
   @moduledoc """
   Options for beginning a new transaction.  Transactions can be created explicitly with calls to Datastore.BeginTransaction or implicitly by setting ReadOptions.new_transaction in read requests.
+
+  ## Attributes
+
+  - readOnly (ReadOnly): The transaction should only allow reads. Defaults to: `null`.
+  - readWrite (ReadWrite): The transaction should allow both reads and writes. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"readOnly",
     :"readWrite"
@@ -35,6 +39,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.TransactionOptions do
     value
     |> deserialize(:"readOnly", :struct, GoogleApi.Datastore.V1.Model.ReadOnly, options)
     |> deserialize(:"readWrite", :struct, GoogleApi.Datastore.V1.Model.ReadWrite, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.TransactionOptions do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/model/value.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/model/value.ex
@@ -20,9 +20,25 @@
 defmodule GoogleApi.Datastore.V1.Model.Value do
   @moduledoc """
   A message that can hold any of the supported value types and associated metadata.
+
+  ## Attributes
+
+  - arrayValue (ArrayValue): An array value. Cannot contain another array value. A &#x60;Value&#x60; instance that sets field &#x60;array_value&#x60; must not set fields &#x60;meaning&#x60; or &#x60;exclude_from_indexes&#x60;. Defaults to: `null`.
+  - blobValue (String): A blob value. May have at most 1,000,000 bytes. When &#x60;exclude_from_indexes&#x60; is false, may have at most 1500 bytes. In JSON requests, must be base64-encoded. Defaults to: `null`.
+  - booleanValue (Boolean): A boolean value. Defaults to: `null`.
+  - doubleValue (Float): A double value. Defaults to: `null`.
+  - entityValue (Entity): An entity value.  - May have no key. - May have a key with an incomplete key path. - May have a reserved/read-only key. Defaults to: `null`.
+  - excludeFromIndexes (Boolean): If the value should be excluded from all indexes including those defined explicitly. Defaults to: `null`.
+  - geoPointValue (LatLng): A geo point value representing a point on the surface of Earth. Defaults to: `null`.
+  - integerValue (String): An integer value. Defaults to: `null`.
+  - keyValue (Key): A key value. Defaults to: `null`.
+  - meaning (Integer): The &#x60;meaning&#x60; field should only be populated for backwards compatibility. Defaults to: `null`.
+  - nullValue (String): A null value. Defaults to: `null`.
+    - Enum - one of [NULL_VALUE]
+  - stringValue (String): A UTF-8 encoded string value. When &#x60;exclude_from_indexes&#x60; is false (it is indexed) , may have at most 1500 bytes. Otherwise, may be set to at least 1,000,000 bytes. Defaults to: `null`.
+  - timestampValue (String): A timestamp value. When stored in the Datastore, precise only to microseconds; any additional precision is rounded down. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"arrayValue",
     :"blobValue",
@@ -48,6 +64,12 @@ defimpl Poison.Decoder, for: GoogleApi.Datastore.V1.Model.Value do
     |> deserialize(:"entityValue", :struct, GoogleApi.Datastore.V1.Model.Entity, options)
     |> deserialize(:"geoPointValue", :struct, GoogleApi.Datastore.V1.Model.LatLng, options)
     |> deserialize(:"keyValue", :struct, GoogleApi.Datastore.V1.Model.Key, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Datastore.V1.Model.Value do
+  def encode(value, options) do
+    GoogleApi.Datastore.V1.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/datastore/lib/google_api/datastore/v1/request_builder.ex
+++ b/clients/datastore/lib/google_api/datastore/v1/request_builder.ex
@@ -22,6 +22,8 @@ defmodule GoogleApi.Datastore.V1.RequestBuilder do
   Helper functions for building Tesla requests
   """
 
+  @path_template_regex ~r/{(\+?[^}]+)}/i
+
   @doc """
   Specify the request method when building a request
 
@@ -51,9 +53,19 @@ defmodule GoogleApi.Datastore.V1.RequestBuilder do
 
   Map
   """
-  @spec url(map(), String.t) :: map()
-  def url(request, u) do
-    Map.put_new(request, :url, u)
+  @spec url(map(), String.t, Map.t) :: map()
+  def url(request, u, replacements) do
+    Map.put_new(request, :url, replace_path_template_vars(u, replacements))
+  end
+
+  def replace_path_template_vars(u, replacements) do
+    Regex.replace(@path_template_regex, u, fn (_, var) -> replacement_value(var, replacements) end)
+  end
+  defp replacement_value("+" <> name, replacements) do
+    URI.decode(replacement_value(name, replacements))
+  end
+  defp replacement_value(name, replacements) do
+    Map.get(replacements, name, "")
   end
 
   @doc """

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -40,7 +40,10 @@ defmodule {{moduleName}}.Api.{{classname}} do
 {{/hasOptionalParams}}
     %{}
     |> method(:{{#underscored}}{{httpMethod}}{{/underscored}})
-    |> url("{{replacedPathName}}")
+    |> url("{{path}}", %{
+         {{#pathParams}}"{{baseName}}" => {{^vendorExtensions.x-allowedReserved}}URI.encode_www_form({{/vendorExtensions.x-allowedReserved}}{{#underscored}}{{paramName}}{{/underscored}}{{^vendorExtensions.x-allowedReserved}}){{/vendorExtensions.x-allowedReserved}}{{#hasMore}},
+       {{/hasMore}}{{/pathParams}}
+       })
 {{#allParams}}
 {{#required}}
 {{^isPathParam}}    |> add_param({{#isBodyParam}}:body{{/isBodyParam}}{{#isFormParam}}{{#isMultipart}}{{#isFile}}:file{{/isFile}}{{^isFile}}:form{{/isFile}}{{/isMultipart}}{{^isMultipart}}:form{{/isMultipart}}{{/isFormParam}}{{#isQueryParam}}:query{{/isQueryParam}}{{#isHeaderParam}}:headers{{/isHeaderParam}}, :"{{baseName}}", {{#underscored}}{{paramName}}{{/underscored}})

--- a/template/deserializer.ex.mustache
+++ b/template/deserializer.ex.mustache
@@ -28,4 +28,12 @@ defmodule {{moduleName}}.Deserializer do
         model
     end
   end
+
+  def serialize_non_nil(model, options) do
+    model
+    |> Map.from_struct
+    |> Enum.filter(fn {_k, v} -> v != nil end)
+    |> Enum.into(%{})
+    |> Poison.Encoder.encode(options)
+  end
 end

--- a/template/model.mustache
+++ b/template/model.mustache
@@ -2,9 +2,17 @@
 {{#models}}{{#model}}defmodule {{moduleName}}.Model.{{classname}} do
   @moduledoc """
   {{description}}
+
+  ## Attributes
+
+  {{#vars}}
+  - {{baseName}} ({{datatype}}): {{description}}{{#defaultValue}} Defaults to: `{{defaultValue}}`.{{/defaultValue}}
+{{#isEnum}}
+    - Enum - one of {{_enum}}
+{{/isEnum}}
+  {{/vars}}
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     {{#vars}}:"{{baseName}}"{{#hasMore}},
     {{/hasMore}}{{/vars}}
@@ -27,6 +35,12 @@ defimpl Poison.Decoder, for: {{moduleName}}.Model.{{classname}} do
   def decode(value, _options) do
     value
 {{/hasComplexVars}}
+  end
+end
+
+defimpl Poison.Encoder, for: {{moduleName}}.Model.{{classname}} do
+  def encode(value, options) do
+    {{moduleName}}.Deserializer.serialize_non_nil(value, options)
   end
 end
 {{/model}}{{/models}}

--- a/template/request_builder.ex.mustache
+++ b/template/request_builder.ex.mustache
@@ -4,6 +4,8 @@ defmodule {{moduleName}}.RequestBuilder do
   Helper functions for building Tesla requests
   """
 
+  @path_template_regex ~r/{(\+?[^}]+)}/i
+
   @doc """
   Specify the request method when building a request
 
@@ -33,9 +35,19 @@ defmodule {{moduleName}}.RequestBuilder do
 
   Map
   """
-  @spec url(map(), String.t) :: map()
-  def url(request, u) do
-    Map.put_new(request, :url, u)
+  @spec url(map(), String.t, Map.t) :: map()
+  def url(request, u, replacements) do
+    Map.put_new(request, :url, replace_path_template_vars(u, replacements))
+  end
+
+  def replace_path_template_vars(u, replacements) do
+    Regex.replace(@path_template_regex, u, fn (_, var) -> replacement_value(var, replacements) end)
+  end
+  defp replacement_value("+" <> name, replacements) do
+    URI.decode(replacement_value(name, replacements))
+  end
+  defp replacement_value(name, replacements) do
+    Map.get(replacements, name, "")
   end
 
   @doc """


### PR DESCRIPTION
In OpenAPI v3, there will be an `allowReserved` attribute on path parameters which we will backport to v2 via the `x-allowReserved` vendor extension.

A converter could change a path: `/foo/{+name}` to `/foo/{name}` and add the `x-allowReserved` vendor extension attribute on the `name` parameter.

This change to the template handles both cases correctly.

This also rebuilds the Datastore client which is blocked by the reserved expansion path templating.