### PR TITLE
Handle missing API definitions

### DIFF
--- a/config/apis.json
+++ b/config/apis.json
@@ -150,11 +150,6 @@
     "url": "https://cloudkms.googleapis.com/$discovery/rest?version=v1"
   },
   {
-    "version": "v2beta2",
-    "name": "CloudMonitoring",
-    "url": "https://www.googleapis.com/discovery/v1/apis/cloudmonitoring/v2beta2/rest"
-  },
-  {
     "version": "v1",
     "name": "CloudResourceManager",
     "url": "https://cloudresourcemanager.googleapis.com/$discovery/rest?version=v1"

--- a/config/apis.json
+++ b/config/apis.json
@@ -386,11 +386,6 @@
   },
   {
     "version": "v1",
-    "name": "PlayMoviesPartner",
-    "url": "https://playmoviespartner.googleapis.com/$discovery/rest?version=v1"
-  },
-  {
-    "version": "v1",
     "name": "Plus",
     "url": "https://www.googleapis.com/discovery/v1/apis/plus/v1/rest"
   },
@@ -413,11 +408,6 @@
     "version": "v1",
     "name": "PubSub",
     "url": "https://pubsub.googleapis.com/$discovery/rest?version=v1"
-  },
-  {
-    "version": "v1",
-    "name": "QPXExpress",
-    "url": "https://www.googleapis.com/discovery/v1/apis/qpxExpress/v1/rest"
   },
   {
     "version": "v1beta2",

--- a/lib/google_apis.ex
+++ b/lib/google_apis.ex
@@ -52,11 +52,13 @@ defmodule GoogleApis do
   def fetch(api_config) do
     file = ApiConfig.google_spec_file(api_config)
 
-    with {:ok, {body, _format}} = GoogleApis.Discovery.fetch(api_config.url),
+    with {:ok, {body, _format}} <- GoogleApis.Discovery.fetch(api_config.url),
          :ok <- File.mkdir_p(Path.dirname(file)),
          :ok <- File.write(file, body)
     do
       {:ok, file}
+    else
+      error -> IO.inspect(error)
     end
   end
 

--- a/lib/google_apis/discovery.ex
+++ b/lib/google_apis/discovery.ex
@@ -15,13 +15,16 @@
 defmodule GoogleApis.Discovery do
   require Logger
 
+  def fetch(""), do: {:error, "No URL"}
   def fetch(url) do
     case Regex.run(~r/(https:\/\/.*\.googleapis.com\/\$discovery\/)([^?]*)(\?.*)?/, url) do
       [_, base, format, query] ->
         try_formats(base, query, ["GOOGLE_REST_SIMPLE_URI", format])
       nil ->
-        {:ok, body} = fetch_direct(url)
-        {:ok, {body, "default"}}
+        case fetch_direct(url) do
+          {:ok, body} -> {:ok, {body, "default"}}
+          error       -> error
+        end
     end
   end
 
@@ -36,6 +39,7 @@ defmodule GoogleApis.Discovery do
   end
 
   defp fetch_direct(url) do
+    Logger.info "FETCHING: #{url}"
     with %Tesla.Env{status: 200, body: body} <- Tesla.get(url)
     do
       Logger.info "FOUND: #{url}"


### PR DESCRIPTION
When calling `mix google_apis.fetch` we now handle 404s from the API discovery service and continue processing.