### PR TITLE
Unwrap api response if the x-dataWrapper vendor extension is present

### DIFF
--- a/clients/translate/lib/google_api/translate/v2/api/detections.ex
+++ b/clients/translate/lib/google_api/translate/v2/api/detections.ex
@@ -33,19 +33,19 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
 
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
   - opts (KeywordList): [optional] Optional parameters
-    - :quota_user (String): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
-    - :pp (Boolean): Pretty-print response.
-    - :oauth_token (String): OAuth 2.0 token for the current user.
-    - :bearer_token (String): OAuth bearer token.
-    - :upload_protocol (String): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
-    - :pretty_print (Boolean): Returns response with indentations and line breaks.
-    - :fields (String): Selector specifying which fields to include in a partial response.
-    - :upload_type (String): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
-    - :__/xgafv (String): V1 error format.
-    - :callback (String): JSONP
-    - :alt (String): Data format for response.
-    - :access_token (String): OAuth access token.
-    - :key (String): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    - :quota_user (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    - :pp (boolean()): Pretty-print response.
+    - :bearer_token (String.t): OAuth bearer token.
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
+    - :pretty_print (boolean()): Returns response with indentations and line breaks.
+    - :fields (String.t): Selector specifying which fields to include in a partial response.
+    - :upload_type (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
+    - :__/xgafv (String.t): V1 error format.
+    - :callback (String.t): JSONP
+    - :alt (String.t): Data format for response.
+    - :access_token (String.t): OAuth access token.
+    - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
     - :body (DetectLanguageRequest): 
 
   ## Returns
@@ -58,8 +58,8 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
     optional_params = %{
       :"quotaUser" => :query,
       :"pp" => :query,
-      :"oauth_token" => :query,
       :"bearer_token" => :query,
+      :"oauth_token" => :query,
       :"upload_protocol" => :query,
       :"prettyPrint" => :query,
       :"fields" => :query,
@@ -77,7 +77,7 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode(%GoogleApi.Translate.V2.Model.DetectionsListResponse{})
+    |> decode(%{"body" => %GoogleApi.Translate.V2.Model.DetectionsListResponse{}})
   end
 
   @doc """
@@ -86,21 +86,21 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
   ## Parameters
 
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
-  - q (List[String]): The input text upon which to perform language detection. Repeat this parameter to perform language detection on multiple text inputs.
+  - q ([String.t]): The input text upon which to perform language detection. Repeat this parameter to perform language detection on multiple text inputs.
   - opts (KeywordList): [optional] Optional parameters
-    - :quota_user (String): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
-    - :pp (Boolean): Pretty-print response.
-    - :oauth_token (String): OAuth 2.0 token for the current user.
-    - :bearer_token (String): OAuth bearer token.
-    - :upload_protocol (String): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
-    - :pretty_print (Boolean): Returns response with indentations and line breaks.
-    - :fields (String): Selector specifying which fields to include in a partial response.
-    - :upload_type (String): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
-    - :__/xgafv (String): V1 error format.
-    - :callback (String): JSONP
-    - :alt (String): Data format for response.
-    - :access_token (String): OAuth access token.
-    - :key (String): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    - :quota_user (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    - :pp (boolean()): Pretty-print response.
+    - :bearer_token (String.t): OAuth bearer token.
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
+    - :pretty_print (boolean()): Returns response with indentations and line breaks.
+    - :fields (String.t): Selector specifying which fields to include in a partial response.
+    - :upload_type (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
+    - :__/xgafv (String.t): V1 error format.
+    - :callback (String.t): JSONP
+    - :alt (String.t): Data format for response.
+    - :access_token (String.t): OAuth access token.
+    - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
 
   ## Returns
 
@@ -112,8 +112,8 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
     optional_params = %{
       :"quotaUser" => :query,
       :"pp" => :query,
-      :"oauth_token" => :query,
       :"bearer_token" => :query,
+      :"oauth_token" => :query,
       :"upload_protocol" => :query,
       :"prettyPrint" => :query,
       :"fields" => :query,
@@ -131,6 +131,6 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode(%GoogleApi.Translate.V2.Model.DetectionsListResponse{})
+    |> decode(%{"body" => %GoogleApi.Translate.V2.Model.DetectionsListResponse{}})
   end
 end

--- a/clients/translate/lib/google_api/translate/v2/api/languages.ex
+++ b/clients/translate/lib/google_api/translate/v2/api/languages.ex
@@ -33,21 +33,21 @@ defmodule GoogleApi.Translate.V2.Api.Languages do
 
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
   - opts (KeywordList): [optional] Optional parameters
-    - :quota_user (String): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
-    - :pp (Boolean): Pretty-print response.
-    - :oauth_token (String): OAuth 2.0 token for the current user.
-    - :bearer_token (String): OAuth bearer token.
-    - :upload_protocol (String): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
-    - :pretty_print (Boolean): Returns response with indentations and line breaks.
-    - :fields (String): Selector specifying which fields to include in a partial response.
-    - :upload_type (String): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
-    - :__/xgafv (String): V1 error format.
-    - :callback (String): JSONP
-    - :alt (String): Data format for response.
-    - :access_token (String): OAuth access token.
-    - :key (String): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
-    - :target (String): The language to use to return localized, human readable names of supported languages.
-    - :model (String): The model type for which supported languages should be returned.
+    - :quota_user (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    - :pp (boolean()): Pretty-print response.
+    - :bearer_token (String.t): OAuth bearer token.
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
+    - :pretty_print (boolean()): Returns response with indentations and line breaks.
+    - :fields (String.t): Selector specifying which fields to include in a partial response.
+    - :upload_type (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
+    - :__/xgafv (String.t): V1 error format.
+    - :callback (String.t): JSONP
+    - :alt (String.t): Data format for response.
+    - :access_token (String.t): OAuth access token.
+    - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    - :target (String.t): The language to use to return localized, human readable names of supported languages.
+    - :model (String.t): The model type for which supported languages should be returned.
 
   ## Returns
 
@@ -59,8 +59,8 @@ defmodule GoogleApi.Translate.V2.Api.Languages do
     optional_params = %{
       :"quotaUser" => :query,
       :"pp" => :query,
-      :"oauth_token" => :query,
       :"bearer_token" => :query,
+      :"oauth_token" => :query,
       :"upload_protocol" => :query,
       :"prettyPrint" => :query,
       :"fields" => :query,
@@ -79,6 +79,6 @@ defmodule GoogleApi.Translate.V2.Api.Languages do
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode(%GoogleApi.Translate.V2.Model.LanguagesListResponse{})
+    |> decode(%{"body" => %GoogleApi.Translate.V2.Model.LanguagesListResponse{}})
   end
 end

--- a/clients/translate/lib/google_api/translate/v2/api/translations.ex
+++ b/clients/translate/lib/google_api/translate/v2/api/translations.ex
@@ -32,26 +32,26 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
   ## Parameters
 
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
-  - q (List[String]): The input text to translate. Repeat this parameter to perform translation operations on multiple text inputs.
-  - target (String): The language to use for translation of the input text, set to one of the language codes listed in Language Support.
+  - q ([String.t]): The input text to translate. Repeat this parameter to perform translation operations on multiple text inputs.
+  - target (String.t): The language to use for translation of the input text, set to one of the language codes listed in Language Support.
   - opts (KeywordList): [optional] Optional parameters
-    - :quota_user (String): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
-    - :pp (Boolean): Pretty-print response.
-    - :oauth_token (String): OAuth 2.0 token for the current user.
-    - :bearer_token (String): OAuth bearer token.
-    - :upload_protocol (String): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
-    - :pretty_print (Boolean): Returns response with indentations and line breaks.
-    - :fields (String): Selector specifying which fields to include in a partial response.
-    - :upload_type (String): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
-    - :__/xgafv (String): V1 error format.
-    - :callback (String): JSONP
-    - :alt (String): Data format for response.
-    - :access_token (String): OAuth access token.
-    - :key (String): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
-    - :source (String): The language of the source text, set to one of the language codes listed in Language Support. If the source language is not specified, the API will attempt to identify the source language automatically and return it within the response.
-    - :cid (List[String]): The customization id for translate
-    - :format (String): The format of the source text, in either HTML (default) or plain-text. A value of \&quot;html\&quot; indicates HTML and a value of \&quot;text\&quot; indicates plain-text.
-    - :model (String): The &#x60;model&#x60; type requested for this translation. Valid values are listed in public documentation.
+    - :quota_user (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    - :pp (boolean()): Pretty-print response.
+    - :bearer_token (String.t): OAuth bearer token.
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
+    - :pretty_print (boolean()): Returns response with indentations and line breaks.
+    - :fields (String.t): Selector specifying which fields to include in a partial response.
+    - :upload_type (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
+    - :__/xgafv (String.t): V1 error format.
+    - :callback (String.t): JSONP
+    - :alt (String.t): Data format for response.
+    - :access_token (String.t): OAuth access token.
+    - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    - :cid ([String.t]): The customization id for translate
+    - :format (String.t): The format of the source text, in either HTML (default) or plain-text. A value of \&quot;html\&quot; indicates HTML and a value of \&quot;text\&quot; indicates plain-text.
+    - :model (String.t): The &#x60;model&#x60; type requested for this translation. Valid values are listed in public documentation.
+    - :source (String.t): The language of the source text, set to one of the language codes listed in Language Support. If the source language is not specified, the API will attempt to identify the source language automatically and return it within the response.
 
   ## Returns
 
@@ -63,8 +63,8 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
     optional_params = %{
       :"quotaUser" => :query,
       :"pp" => :query,
-      :"oauth_token" => :query,
       :"bearer_token" => :query,
+      :"oauth_token" => :query,
       :"upload_protocol" => :query,
       :"prettyPrint" => :query,
       :"fields" => :query,
@@ -74,10 +74,10 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
       :"alt" => :query,
       :"access_token" => :query,
       :"key" => :query,
-      :"source" => :query,
       :"cid" => :query,
       :"format" => :query,
-      :"model" => :query
+      :"model" => :query,
+      :"source" => :query
     }
     %{}
     |> method(:get)
@@ -87,7 +87,7 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode(%GoogleApi.Translate.V2.Model.TranslationsListResponse{})
+    |> decode(%{"body" => %GoogleApi.Translate.V2.Model.TranslationsListResponse{}})
   end
 
   @doc """
@@ -97,19 +97,19 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
 
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
   - opts (KeywordList): [optional] Optional parameters
-    - :quota_user (String): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
-    - :pp (Boolean): Pretty-print response.
-    - :oauth_token (String): OAuth 2.0 token for the current user.
-    - :bearer_token (String): OAuth bearer token.
-    - :upload_protocol (String): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
-    - :pretty_print (Boolean): Returns response with indentations and line breaks.
-    - :fields (String): Selector specifying which fields to include in a partial response.
-    - :upload_type (String): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
-    - :__/xgafv (String): V1 error format.
-    - :callback (String): JSONP
-    - :alt (String): Data format for response.
-    - :access_token (String): OAuth access token.
-    - :key (String): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    - :quota_user (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    - :pp (boolean()): Pretty-print response.
+    - :bearer_token (String.t): OAuth bearer token.
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
+    - :pretty_print (boolean()): Returns response with indentations and line breaks.
+    - :fields (String.t): Selector specifying which fields to include in a partial response.
+    - :upload_type (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
+    - :__/xgafv (String.t): V1 error format.
+    - :callback (String.t): JSONP
+    - :alt (String.t): Data format for response.
+    - :access_token (String.t): OAuth access token.
+    - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
     - :body (TranslateTextRequest): 
 
   ## Returns
@@ -122,8 +122,8 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
     optional_params = %{
       :"quotaUser" => :query,
       :"pp" => :query,
-      :"oauth_token" => :query,
       :"bearer_token" => :query,
+      :"oauth_token" => :query,
       :"upload_protocol" => :query,
       :"prettyPrint" => :query,
       :"fields" => :query,
@@ -141,6 +141,6 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode(%GoogleApi.Translate.V2.Model.TranslationsListResponse{})
+    |> decode(%{"body" => %GoogleApi.Translate.V2.Model.TranslationsListResponse{}})
   end
 end

--- a/clients/translate/lib/google_api/translate/v2/deserializer.ex
+++ b/clients/translate/lib/google_api/translate/v2/deserializer.ex
@@ -26,6 +26,7 @@ defmodule GoogleApi.Translate.V2.Deserializer do
   Update the provided model with a deserialization of a nested value
   """
   @spec deserialize(struct(), :atom, :atom, struct(), keyword()) :: struct()
+  def deserialize(model, _field, :list, nil, _options), do: model
   def deserialize(model, field, :list, mod, options) do
     model
     |> Map.update!(field, &(Poison.Decode.decode(&1, Keyword.merge(options, [as: [struct(mod)]]))))
@@ -34,9 +35,10 @@ defmodule GoogleApi.Translate.V2.Deserializer do
     model
     |> Map.update!(field, &(Poison.Decode.decode(&1, Keyword.merge(options, [as: struct(mod)]))))
   end
+  def deserialize(model, _field, :map, nil, _options), do: model
   def deserialize(model, field, :map, mod, options) do
     model
-    |> Map.update!(field, &(Map.new(&1, fn {key, val} -> {key, Poison.Decode.decode(val, Keyword.merge(options, [as: struct(mod)]))} end)))
+    |> Map.update!(field, &(Map.new(&1 || %{}, fn {key, val} -> {key, Poison.Decode.decode(val, Keyword.merge(options, [as: struct(mod)]))} end)))
   end
   def deserialize(model, field, :date, _, _options) do
     case DateTime.from_iso8601(Map.get(model, field)) do
@@ -45,5 +47,13 @@ defmodule GoogleApi.Translate.V2.Deserializer do
       _ ->
         model
     end
+  end
+
+  def serialize_non_nil(model, options) do
+    model
+    |> Map.from_struct
+    |> Enum.filter(fn {_k, v} -> v != nil end)
+    |> Enum.into(%{})
+    |> Poison.Encoder.encode(options)
   end
 end

--- a/clients/translate/lib/google_api/translate/v2/model/detect_language_request.ex
+++ b/clients/translate/lib/google_api/translate/v2/model/detect_language_request.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Translate.V2.Model.DetectLanguageRequest do
   @moduledoc """
   The request message for language detection.
+
+  ## Attributes
+
+  - q ([String.t]): The input text upon which to perform language detection. Repeat this parameter to perform language detection on multiple text inputs. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"q"
   ]
@@ -31,6 +34,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Translate.V2.Model.DetectLanguageRequest do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Translate.V2.Model.DetectLanguageRequest do
+  def encode(value, options) do
+    GoogleApi.Translate.V2.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/translate/lib/google_api/translate/v2/model/detections_list_response.ex
+++ b/clients/translate/lib/google_api/translate/v2/model/detections_list_response.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Translate.V2.Model.DetectionsListResponse do
   @moduledoc """
   
+
+  ## Attributes
+
+  - detections ([DetectionsResource]): A detections contains detection results of several text Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"detections"
   ]
@@ -33,6 +36,12 @@ defimpl Poison.Decoder, for: GoogleApi.Translate.V2.Model.DetectionsListResponse
   def decode(value, options) do
     value
     |> deserialize(:"detections", :list, GoogleApi.Translate.V2.Model.DetectionsResource, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Translate.V2.Model.DetectionsListResponse do
+  def encode(value, options) do
+    GoogleApi.Translate.V2.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/translate/lib/google_api/translate/v2/model/detections_resource.ex
+++ b/clients/translate/lib/google_api/translate/v2/model/detections_resource.ex
@@ -20,9 +20,11 @@
 defmodule GoogleApi.Translate.V2.Model.DetectionsResource do
   @moduledoc """
   An array of languages which we detect for the given text The most likely language list first.
+
+  ## Attributes
+
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     
   ]
@@ -31,6 +33,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Translate.V2.Model.DetectionsResource do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Translate.V2.Model.DetectionsResource do
+  def encode(value, options) do
+    GoogleApi.Translate.V2.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/translate/lib/google_api/translate/v2/model/detections_resource_inner.ex
+++ b/clients/translate/lib/google_api/translate/v2/model/detections_resource_inner.ex
@@ -17,12 +17,17 @@
 # https://github.com/swagger-api/swagger-codegen.git
 # Do not edit the class manually.
 
-defmodule GoogleApi.Translate.V2.Model.DetectionsResource_inner do
+defmodule GoogleApi.Translate.V2.Model.DetectionsResourceInner do
   @moduledoc """
   
+
+  ## Attributes
+
+  - confidence (float()): The confidence of the detection result of this language. Defaults to: `null`.
+  - isReliable (boolean()): A boolean to indicate is the language detection result reliable. Defaults to: `null`.
+  - language (String.t): The language we detected. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"confidence",
     :"isReliable",
@@ -30,9 +35,15 @@ defmodule GoogleApi.Translate.V2.Model.DetectionsResource_inner do
   ]
 end
 
-defimpl Poison.Decoder, for: GoogleApi.Translate.V2.Model.DetectionsResource_inner do
+defimpl Poison.Decoder, for: GoogleApi.Translate.V2.Model.DetectionsResourceInner do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Translate.V2.Model.DetectionsResourceInner do
+  def encode(value, options) do
+    GoogleApi.Translate.V2.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/translate/lib/google_api/translate/v2/model/get_supported_languages_request.ex
+++ b/clients/translate/lib/google_api/translate/v2/model/get_supported_languages_request.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Translate.V2.Model.GetSupportedLanguagesRequest do
   @moduledoc """
   The request message for discovering supported languages.
+
+  ## Attributes
+
+  - target (String.t): The language to use to return localized, human readable names of supported languages. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"target"
   ]
@@ -31,6 +34,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Translate.V2.Model.GetSupportedLanguagesRequest do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Translate.V2.Model.GetSupportedLanguagesRequest do
+  def encode(value, options) do
+    GoogleApi.Translate.V2.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/translate/lib/google_api/translate/v2/model/languages_list_response.ex
+++ b/clients/translate/lib/google_api/translate/v2/model/languages_list_response.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Translate.V2.Model.LanguagesListResponse do
   @moduledoc """
   
+
+  ## Attributes
+
+  - languages ([LanguagesResource]): List of source/target languages supported by the translation API. If target parameter is unspecified, the list is sorted by the ASCII code point order of the language code. If target parameter is specified, the list is sorted by the collation order of the language name in the target language. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"languages"
   ]
@@ -33,6 +36,12 @@ defimpl Poison.Decoder, for: GoogleApi.Translate.V2.Model.LanguagesListResponse 
   def decode(value, options) do
     value
     |> deserialize(:"languages", :list, GoogleApi.Translate.V2.Model.LanguagesResource, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Translate.V2.Model.LanguagesListResponse do
+  def encode(value, options) do
+    GoogleApi.Translate.V2.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/translate/lib/google_api/translate/v2/model/languages_resource.ex
+++ b/clients/translate/lib/google_api/translate/v2/model/languages_resource.ex
@@ -20,9 +20,13 @@
 defmodule GoogleApi.Translate.V2.Model.LanguagesResource do
   @moduledoc """
   
+
+  ## Attributes
+
+  - language (String.t): Supported language code, generally consisting of its ISO 639-1 identifier. (E.g. &#39;en&#39;, &#39;ja&#39;). In certain cases, BCP-47 codes including language + region identifiers are returned (e.g. &#39;zh-TW&#39; and &#39;zh-CH&#39;) Defaults to: `null`.
+  - name (String.t): Human readable name of the language localized to the target language. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"language",
     :"name"
@@ -32,6 +36,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Translate.V2.Model.LanguagesResource do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Translate.V2.Model.LanguagesResource do
+  def encode(value, options) do
+    GoogleApi.Translate.V2.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/translate/lib/google_api/translate/v2/model/translate_text_request.ex
+++ b/clients/translate/lib/google_api/translate/v2/model/translate_text_request.ex
@@ -20,9 +20,16 @@
 defmodule GoogleApi.Translate.V2.Model.TranslateTextRequest do
   @moduledoc """
   The main translation request message for the Cloud Translation API.
+
+  ## Attributes
+
+  - format (String.t): The format of the source text, in either HTML (default) or plain-text. A value of \&quot;html\&quot; indicates HTML and a value of \&quot;text\&quot; indicates plain-text. Defaults to: `null`.
+  - model (String.t): The &#x60;model&#x60; type requested for this translation. Valid values are listed in public documentation. Defaults to: `null`.
+  - q ([String.t]): The input text to translate. Repeat this parameter to perform translation operations on multiple text inputs. Defaults to: `null`.
+  - source (String.t): The language of the source text, set to one of the language codes listed in Language Support. If the source language is not specified, the API will attempt to identify the source language automatically and return it within the response. Defaults to: `null`.
+  - target (String.t): The language to use for translation of the input text, set to one of the language codes listed in Language Support. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"format",
     :"model",
@@ -35,6 +42,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Translate.V2.Model.TranslateTextRequest do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Translate.V2.Model.TranslateTextRequest do
+  def encode(value, options) do
+    GoogleApi.Translate.V2.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/translate/lib/google_api/translate/v2/model/translations_list_response.ex
+++ b/clients/translate/lib/google_api/translate/v2/model/translations_list_response.ex
@@ -20,9 +20,12 @@
 defmodule GoogleApi.Translate.V2.Model.TranslationsListResponse do
   @moduledoc """
   The main language translation response message.
+
+  ## Attributes
+
+  - translations ([TranslationsResource]): Translations contains list of translation results of given text Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"translations"
   ]
@@ -33,6 +36,12 @@ defimpl Poison.Decoder, for: GoogleApi.Translate.V2.Model.TranslationsListRespon
   def decode(value, options) do
     value
     |> deserialize(:"translations", :list, GoogleApi.Translate.V2.Model.TranslationsResource, options)
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Translate.V2.Model.TranslationsListResponse do
+  def encode(value, options) do
+    GoogleApi.Translate.V2.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/translate/lib/google_api/translate/v2/model/translations_resource.ex
+++ b/clients/translate/lib/google_api/translate/v2/model/translations_resource.ex
@@ -20,9 +20,14 @@
 defmodule GoogleApi.Translate.V2.Model.TranslationsResource do
   @moduledoc """
   
+
+  ## Attributes
+
+  - detectedSourceLanguage (String.t): The source language of the initial request, detected automatically, if no source language was passed within the initial request. If the source language was passed, auto-detection of the language will not occur and this field will be empty. Defaults to: `null`.
+  - model (String.t): The &#x60;model&#x60; type used for this translation. Valid values are listed in public documentation. Can be different from requested &#x60;model&#x60;. Present only if specific model type was explicitly requested. Defaults to: `null`.
+  - translatedText (String.t): Text translated into the target language. Defaults to: `null`.
   """
 
-  @derive [Poison.Encoder]
   defstruct [
     :"detectedSourceLanguage",
     :"model",
@@ -33,6 +38,12 @@ end
 defimpl Poison.Decoder, for: GoogleApi.Translate.V2.Model.TranslationsResource do
   def decode(value, _options) do
     value
+  end
+end
+
+defimpl Poison.Encoder, for: GoogleApi.Translate.V2.Model.TranslationsResource do
+  def encode(value, options) do
+    GoogleApi.Translate.V2.Deserializer.serialize_non_nil(value, options)
   end
 end
 

--- a/clients/translate/lib/google_api/translate/v2/request_builder.ex
+++ b/clients/translate/lib/google_api/translate/v2/request_builder.ex
@@ -22,6 +22,8 @@ defmodule GoogleApi.Translate.V2.RequestBuilder do
   Helper functions for building Tesla requests
   """
 
+  @path_template_regex ~r/{(\+?[^}]+)}/i
+
   @doc """
   Specify the request method when building a request
 
@@ -51,9 +53,22 @@ defmodule GoogleApi.Translate.V2.RequestBuilder do
 
   Map
   """
-  @spec url(map(), String.t) :: map()
+  @spec url(map(), String.t, Map.t) :: map()
+  def url(request, u, replacements) do
+    url(request, replace_path_template_vars(u, replacements))
+  end
   def url(request, u) do
     Map.put_new(request, :url, u)
+  end
+
+  def replace_path_template_vars(u, replacements) do
+    Regex.replace(@path_template_regex, u, fn (_, var) -> replacement_value(var, replacements) end)
+  end
+  defp replacement_value("+" <> name, replacements) do
+    URI.decode(replacement_value(name, replacements))
+  end
+  defp replacement_value(name, replacements) do
+    Map.get(replacements, name, "")
   end
 
   @doc """

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -54,7 +54,7 @@ defmodule {{moduleName}}.Api.{{classname}} do
 {{/hasOptionalParams}}
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode({{decodedStruct}})
+    |> decode({{#vendorExtensions.x-dataWrapper}}%{"body" => {{/vendorExtensions.x-dataWrapper}}{{decodedStruct}}{{#vendorExtensions.x-dataWrapper}}}{{/vendorExtensions.x-dataWrapper}})
   end
   {{/operation}}
 {{/operations}}


### PR DESCRIPTION
Fixes #38 

The api converter handles the `features[dataWrapper]` and converts to a `x-dataWrapper` vendor extension available for each operation.

If the x-dataWrapper option is present for an operation, we unwrap the data when deserializing using Poison.