### PR TITLE
Use elixir 1.6 code formatter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: elixir
 elixir:
-  - 1.4.5
-  - 1.5.1
+  - 1.6.0
 otp_release:
   - 19.3
   - 20.0

--- a/lib/google_apis.ex
+++ b/lib/google_apis.ex
@@ -79,4 +79,11 @@ defmodule GoogleApis do
     generator = Application.get_env(:google_apis, :client_generator)
     generator.generate_client(api_config)
   end
+
+  def format_client(api_config) do
+    name = GoogleApis.ApiConfig.library_name(api_config)
+
+    ["clients/#{name}/lib/**/*.{ex,exs}"]
+    |> Mix.Tasks.Format.run    
+  end
 end

--- a/lib/mix/tasks/google_apis.format.ex
+++ b/lib/mix/tasks/google_apis.format.ex
@@ -1,0 +1,28 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Mix.Tasks.GoogleApis.Format do
+  use Mix.Task
+
+  @shortdoc "Format generated client code"
+
+  def run([only]) do
+    only
+    |> GoogleApis.ApiConfig.load()
+    |> Enum.each(&GoogleApis.format_client/1)
+  end
+  def run(_) do
+    Enum.each(GoogleApis.ApiConfig.load_all(), &GoogleApis.format_client/1)
+  end
+end

--- a/lib/mix/tasks/google_apis.generate.ex
+++ b/lib/mix/tasks/google_apis.generate.ex
@@ -1,0 +1,38 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Mix.Tasks.GoogleApis.Generate do
+  use Mix.Task
+
+  @shortdoc "Generate clients"
+
+  def run([only]) do
+    only
+    |> GoogleApis.ApiConfig.load()
+    |> builder()
+  end
+  def run(_) do
+    builder(GoogleApis.ApiConfig.load_all())
+  end
+
+  defp builder(apis) do
+    Enum.each(apis, fn api ->
+      GoogleApis.fetch(api)
+      GoogleApis.convert(api)
+      GoogleApis.generate_config(api)
+      GoogleApis.generate_client(api)
+      GoogleApis.format_client(api)
+    end)
+  end
+end

--- a/lib/mix/tasks/google_apis.generate.ex
+++ b/lib/mix/tasks/google_apis.generate.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.GoogleApis.Generate do
   defp builder(apis) do
     Enum.each(apis, fn api ->
       GoogleApis.fetch(api)
-      GoogleApis.convert(api)
+      GoogleApis.convert_spec(api)
       GoogleApis.generate_config(api)
       GoogleApis.generate_client(api)
       GoogleApis.format_client(api)

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule GoogleApis.Mixfile do
   def project do
     [app: :google_apis,
      version: "0.1.0",
-     elixir: "~> 1.4",
+     elixir: "~> 1.6",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps()]


### PR DESCRIPTION
* Add an additional mix task `mix google_apis.format [library-name]` - runs code formatter on the specified library (or all libraries if not provided)
* Add an additional mix task `mix google_apis.generate [library-name]` - rebuilds the specified library from scratch (download, convert, build, format).