### PR TITLE
Fix dataWrapped return values

### DIFF
--- a/clients/translate/config/config.exs
+++ b/clients/translate/config/config.exs
@@ -28,3 +28,4 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
+config :goth, json: {:system, "GCP_CREDENTIALS"}

--- a/clients/translate/lib/google_api/translate/v2/api/detections.ex
+++ b/clients/translate/lib/google_api/translate/v2/api/detections.ex
@@ -31,19 +31,19 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
 
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
   - opts (KeywordList): [optional] Optional parameters
-    - :oauth_token (String.t): OAuth 2.0 token for the current user.
-    - :bearer_token (String.t): OAuth bearer token.
     - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
     - :prettyPrint (boolean()): Returns response with indentations and line breaks.
     - :uploadType (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
     - :fields (String.t): Selector specifying which fields to include in a partial response.
-    - :callback (String.t): JSONP
     - :$.xgafv (String.t): V1 error format.
+    - :callback (String.t): JSONP
     - :alt (String.t): Data format for response.
     - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
     - :access_token (String.t): OAuth access token.
     - :quotaUser (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
     - :pp (boolean()): Pretty-print response.
+    - :bearer_token (String.t): OAuth bearer token.
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
     - :body (DetectLanguageRequest): 
 
   ## Returns
@@ -55,19 +55,19 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
           {:ok, GoogleApi.Translate.V2.Model.DetectionsListResponse.t()} | {:error, Tesla.Env.t()}
   def language_detections_detect(connection, opts \\ []) do
     optional_params = %{
-      :oauth_token => :query,
-      :bearer_token => :query,
       :upload_protocol => :query,
       :prettyPrint => :query,
       :uploadType => :query,
       :fields => :query,
-      :callback => :query,
       :"$.xgafv" => :query,
+      :callback => :query,
       :alt => :query,
       :key => :query,
       :access_token => :query,
       :quotaUser => :query,
       :pp => :query,
+      :bearer_token => :query,
+      :oauth_token => :query,
       :body => :body
     }
 
@@ -77,7 +77,7 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode(%{"body" => %GoogleApi.Translate.V2.Model.DetectionsListResponse{}})
+    |> decode(%GoogleApi.Translate.V2.Model.DetectionsListResponse{}, dataWrapped: true)
   end
 
   @doc """
@@ -88,19 +88,19 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
   - q ([String.t]): The input text upon which to perform language detection. Repeat this parameter to perform language detection on multiple text inputs.
   - opts (KeywordList): [optional] Optional parameters
-    - :oauth_token (String.t): OAuth 2.0 token for the current user.
-    - :bearer_token (String.t): OAuth bearer token.
     - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
     - :prettyPrint (boolean()): Returns response with indentations and line breaks.
     - :uploadType (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
     - :fields (String.t): Selector specifying which fields to include in a partial response.
-    - :callback (String.t): JSONP
     - :$.xgafv (String.t): V1 error format.
+    - :callback (String.t): JSONP
     - :alt (String.t): Data format for response.
     - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
     - :access_token (String.t): OAuth access token.
     - :quotaUser (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
     - :pp (boolean()): Pretty-print response.
+    - :bearer_token (String.t): OAuth bearer token.
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
 
   ## Returns
 
@@ -111,19 +111,19 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
           {:ok, GoogleApi.Translate.V2.Model.DetectionsListResponse.t()} | {:error, Tesla.Env.t()}
   def language_detections_list(connection, q, opts \\ []) do
     optional_params = %{
-      :oauth_token => :query,
-      :bearer_token => :query,
       :upload_protocol => :query,
       :prettyPrint => :query,
       :uploadType => :query,
       :fields => :query,
-      :callback => :query,
       :"$.xgafv" => :query,
+      :callback => :query,
       :alt => :query,
       :key => :query,
       :access_token => :query,
       :quotaUser => :query,
-      :pp => :query
+      :pp => :query,
+      :bearer_token => :query,
+      :oauth_token => :query
     }
 
     %{}
@@ -133,6 +133,6 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode(%{"body" => %GoogleApi.Translate.V2.Model.DetectionsListResponse{}})
+    |> decode(%GoogleApi.Translate.V2.Model.DetectionsListResponse{}, dataWrapped: true)
   end
 end

--- a/clients/translate/lib/google_api/translate/v2/api/detections.ex
+++ b/clients/translate/lib/google_api/translate/v2/api/detections.ex
@@ -31,19 +31,19 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
 
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
   - opts (KeywordList): [optional] Optional parameters
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :bearer_token (String.t): OAuth bearer token.
     - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
     - :prettyPrint (boolean()): Returns response with indentations and line breaks.
     - :uploadType (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
     - :fields (String.t): Selector specifying which fields to include in a partial response.
-    - :$.xgafv (String.t): V1 error format.
     - :callback (String.t): JSONP
+    - :$.xgafv (String.t): V1 error format.
     - :alt (String.t): Data format for response.
     - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
     - :access_token (String.t): OAuth access token.
     - :quotaUser (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
     - :pp (boolean()): Pretty-print response.
-    - :bearer_token (String.t): OAuth bearer token.
-    - :oauth_token (String.t): OAuth 2.0 token for the current user.
     - :body (DetectLanguageRequest): 
 
   ## Returns
@@ -55,19 +55,19 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
           {:ok, GoogleApi.Translate.V2.Model.DetectionsListResponse.t()} | {:error, Tesla.Env.t()}
   def language_detections_detect(connection, opts \\ []) do
     optional_params = %{
+      :oauth_token => :query,
+      :bearer_token => :query,
       :upload_protocol => :query,
       :prettyPrint => :query,
       :uploadType => :query,
       :fields => :query,
-      :"$.xgafv" => :query,
       :callback => :query,
+      :"$.xgafv" => :query,
       :alt => :query,
       :key => :query,
       :access_token => :query,
       :quotaUser => :query,
       :pp => :query,
-      :bearer_token => :query,
-      :oauth_token => :query,
       :body => :body
     }
 
@@ -88,19 +88,19 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
   - q ([String.t]): The input text upon which to perform language detection. Repeat this parameter to perform language detection on multiple text inputs.
   - opts (KeywordList): [optional] Optional parameters
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :bearer_token (String.t): OAuth bearer token.
     - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
     - :prettyPrint (boolean()): Returns response with indentations and line breaks.
     - :uploadType (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
     - :fields (String.t): Selector specifying which fields to include in a partial response.
-    - :$.xgafv (String.t): V1 error format.
     - :callback (String.t): JSONP
+    - :$.xgafv (String.t): V1 error format.
     - :alt (String.t): Data format for response.
     - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
     - :access_token (String.t): OAuth access token.
     - :quotaUser (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
     - :pp (boolean()): Pretty-print response.
-    - :bearer_token (String.t): OAuth bearer token.
-    - :oauth_token (String.t): OAuth 2.0 token for the current user.
 
   ## Returns
 
@@ -111,19 +111,19 @@ defmodule GoogleApi.Translate.V2.Api.Detections do
           {:ok, GoogleApi.Translate.V2.Model.DetectionsListResponse.t()} | {:error, Tesla.Env.t()}
   def language_detections_list(connection, q, opts \\ []) do
     optional_params = %{
+      :oauth_token => :query,
+      :bearer_token => :query,
       :upload_protocol => :query,
       :prettyPrint => :query,
       :uploadType => :query,
       :fields => :query,
-      :"$.xgafv" => :query,
       :callback => :query,
+      :"$.xgafv" => :query,
       :alt => :query,
       :key => :query,
       :access_token => :query,
       :quotaUser => :query,
-      :pp => :query,
-      :bearer_token => :query,
-      :oauth_token => :query
+      :pp => :query
     }
 
     %{}

--- a/clients/translate/lib/google_api/translate/v2/api/languages.ex
+++ b/clients/translate/lib/google_api/translate/v2/api/languages.ex
@@ -31,19 +31,19 @@ defmodule GoogleApi.Translate.V2.Api.Languages do
 
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
   - opts (KeywordList): [optional] Optional parameters
-    - :oauth_token (String.t): OAuth 2.0 token for the current user.
-    - :bearer_token (String.t): OAuth bearer token.
     - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
     - :prettyPrint (boolean()): Returns response with indentations and line breaks.
     - :uploadType (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
     - :fields (String.t): Selector specifying which fields to include in a partial response.
-    - :callback (String.t): JSONP
     - :$.xgafv (String.t): V1 error format.
+    - :callback (String.t): JSONP
     - :alt (String.t): Data format for response.
     - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
     - :access_token (String.t): OAuth access token.
     - :quotaUser (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
     - :pp (boolean()): Pretty-print response.
+    - :bearer_token (String.t): OAuth bearer token.
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
     - :model (String.t): The model type for which supported languages should be returned.
     - :target (String.t): The language to use to return localized, human readable names of supported languages.
 
@@ -56,19 +56,19 @@ defmodule GoogleApi.Translate.V2.Api.Languages do
           {:ok, GoogleApi.Translate.V2.Model.LanguagesListResponse.t()} | {:error, Tesla.Env.t()}
   def language_languages_list(connection, opts \\ []) do
     optional_params = %{
-      :oauth_token => :query,
-      :bearer_token => :query,
       :upload_protocol => :query,
       :prettyPrint => :query,
       :uploadType => :query,
       :fields => :query,
-      :callback => :query,
       :"$.xgafv" => :query,
+      :callback => :query,
       :alt => :query,
       :key => :query,
       :access_token => :query,
       :quotaUser => :query,
       :pp => :query,
+      :bearer_token => :query,
+      :oauth_token => :query,
       :model => :query,
       :target => :query
     }
@@ -79,6 +79,6 @@ defmodule GoogleApi.Translate.V2.Api.Languages do
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode(%{"body" => %GoogleApi.Translate.V2.Model.LanguagesListResponse{}})
+    |> decode(%GoogleApi.Translate.V2.Model.LanguagesListResponse{}, dataWrapped: true)
   end
 end

--- a/clients/translate/lib/google_api/translate/v2/api/languages.ex
+++ b/clients/translate/lib/google_api/translate/v2/api/languages.ex
@@ -31,21 +31,21 @@ defmodule GoogleApi.Translate.V2.Api.Languages do
 
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
   - opts (KeywordList): [optional] Optional parameters
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :bearer_token (String.t): OAuth bearer token.
     - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
     - :prettyPrint (boolean()): Returns response with indentations and line breaks.
     - :uploadType (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
     - :fields (String.t): Selector specifying which fields to include in a partial response.
-    - :$.xgafv (String.t): V1 error format.
     - :callback (String.t): JSONP
+    - :$.xgafv (String.t): V1 error format.
     - :alt (String.t): Data format for response.
     - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
     - :access_token (String.t): OAuth access token.
     - :quotaUser (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
     - :pp (boolean()): Pretty-print response.
-    - :bearer_token (String.t): OAuth bearer token.
-    - :oauth_token (String.t): OAuth 2.0 token for the current user.
-    - :model (String.t): The model type for which supported languages should be returned.
     - :target (String.t): The language to use to return localized, human readable names of supported languages.
+    - :model (String.t): The model type for which supported languages should be returned.
 
   ## Returns
 
@@ -56,21 +56,21 @@ defmodule GoogleApi.Translate.V2.Api.Languages do
           {:ok, GoogleApi.Translate.V2.Model.LanguagesListResponse.t()} | {:error, Tesla.Env.t()}
   def language_languages_list(connection, opts \\ []) do
     optional_params = %{
+      :oauth_token => :query,
+      :bearer_token => :query,
       :upload_protocol => :query,
       :prettyPrint => :query,
       :uploadType => :query,
       :fields => :query,
-      :"$.xgafv" => :query,
       :callback => :query,
+      :"$.xgafv" => :query,
       :alt => :query,
       :key => :query,
       :access_token => :query,
       :quotaUser => :query,
       :pp => :query,
-      :bearer_token => :query,
-      :oauth_token => :query,
-      :model => :query,
-      :target => :query
+      :target => :query,
+      :model => :query
     }
 
     %{}

--- a/clients/translate/lib/google_api/translate/v2/api/translations.ex
+++ b/clients/translate/lib/google_api/translate/v2/api/translations.ex
@@ -33,23 +33,23 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
   - q ([String.t]): The input text to translate. Repeat this parameter to perform translation operations on multiple text inputs.
   - target (String.t): The language to use for translation of the input text, set to one of the language codes listed in Language Support.
   - opts (KeywordList): [optional] Optional parameters
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :bearer_token (String.t): OAuth bearer token.
     - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
     - :prettyPrint (boolean()): Returns response with indentations and line breaks.
     - :uploadType (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
     - :fields (String.t): Selector specifying which fields to include in a partial response.
-    - :$.xgafv (String.t): V1 error format.
     - :callback (String.t): JSONP
+    - :$.xgafv (String.t): V1 error format.
     - :alt (String.t): Data format for response.
     - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
     - :access_token (String.t): OAuth access token.
     - :quotaUser (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
     - :pp (boolean()): Pretty-print response.
-    - :bearer_token (String.t): OAuth bearer token.
-    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :format (String.t): The format of the source text, in either HTML (default) or plain-text. A value of \&quot;html\&quot; indicates HTML and a value of \&quot;text\&quot; indicates plain-text.
     - :model (String.t): The &#x60;model&#x60; type requested for this translation. Valid values are listed in public documentation.
     - :source (String.t): The language of the source text, set to one of the language codes listed in Language Support. If the source language is not specified, the API will attempt to identify the source language automatically and return it within the response.
     - :cid ([String.t]): The customization id for translate
-    - :format (String.t): The format of the source text, in either HTML (default) or plain-text. A value of \&quot;html\&quot; indicates HTML and a value of \&quot;text\&quot; indicates plain-text.
 
   ## Returns
 
@@ -61,23 +61,23 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
           | {:error, Tesla.Env.t()}
   def language_translations_list(connection, q, target, opts \\ []) do
     optional_params = %{
+      :oauth_token => :query,
+      :bearer_token => :query,
       :upload_protocol => :query,
       :prettyPrint => :query,
       :uploadType => :query,
       :fields => :query,
-      :"$.xgafv" => :query,
       :callback => :query,
+      :"$.xgafv" => :query,
       :alt => :query,
       :key => :query,
       :access_token => :query,
       :quotaUser => :query,
       :pp => :query,
-      :bearer_token => :query,
-      :oauth_token => :query,
+      :format => :query,
       :model => :query,
       :source => :query,
-      :cid => :query,
-      :format => :query
+      :cid => :query
     }
 
     %{}
@@ -98,19 +98,19 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
 
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
   - opts (KeywordList): [optional] Optional parameters
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :bearer_token (String.t): OAuth bearer token.
     - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
     - :prettyPrint (boolean()): Returns response with indentations and line breaks.
     - :uploadType (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
     - :fields (String.t): Selector specifying which fields to include in a partial response.
-    - :$.xgafv (String.t): V1 error format.
     - :callback (String.t): JSONP
+    - :$.xgafv (String.t): V1 error format.
     - :alt (String.t): Data format for response.
     - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
     - :access_token (String.t): OAuth access token.
     - :quotaUser (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
     - :pp (boolean()): Pretty-print response.
-    - :bearer_token (String.t): OAuth bearer token.
-    - :oauth_token (String.t): OAuth 2.0 token for the current user.
     - :body (TranslateTextRequest): 
 
   ## Returns
@@ -123,19 +123,19 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
           | {:error, Tesla.Env.t()}
   def language_translations_translate(connection, opts \\ []) do
     optional_params = %{
+      :oauth_token => :query,
+      :bearer_token => :query,
       :upload_protocol => :query,
       :prettyPrint => :query,
       :uploadType => :query,
       :fields => :query,
-      :"$.xgafv" => :query,
       :callback => :query,
+      :"$.xgafv" => :query,
       :alt => :query,
       :key => :query,
       :access_token => :query,
       :quotaUser => :query,
       :pp => :query,
-      :bearer_token => :query,
-      :oauth_token => :query,
       :body => :body
     }
 

--- a/clients/translate/lib/google_api/translate/v2/api/translations.ex
+++ b/clients/translate/lib/google_api/translate/v2/api/translations.ex
@@ -111,7 +111,7 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
     - :access_token (String.t): OAuth access token.
     - :quotaUser (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
     - :pp (boolean()): Pretty-print response.
-    - :body (TranslateTextRequest): 
+    - :body (TranslateTextRequest):
 
   ## Returns
 
@@ -145,6 +145,6 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode(%{"body" => %GoogleApi.Translate.V2.Model.TranslationsListResponse{}})
+    |> decode(%GoogleApi.Translate.V2.Model.TranslationsListResponse{}, true)
   end
 end

--- a/clients/translate/lib/google_api/translate/v2/api/translations.ex
+++ b/clients/translate/lib/google_api/translate/v2/api/translations.ex
@@ -33,23 +33,23 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
   - q ([String.t]): The input text to translate. Repeat this parameter to perform translation operations on multiple text inputs.
   - target (String.t): The language to use for translation of the input text, set to one of the language codes listed in Language Support.
   - opts (KeywordList): [optional] Optional parameters
-    - :oauth_token (String.t): OAuth 2.0 token for the current user.
-    - :bearer_token (String.t): OAuth bearer token.
     - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
     - :prettyPrint (boolean()): Returns response with indentations and line breaks.
     - :uploadType (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
     - :fields (String.t): Selector specifying which fields to include in a partial response.
-    - :callback (String.t): JSONP
     - :$.xgafv (String.t): V1 error format.
+    - :callback (String.t): JSONP
     - :alt (String.t): Data format for response.
     - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
     - :access_token (String.t): OAuth access token.
     - :quotaUser (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
     - :pp (boolean()): Pretty-print response.
+    - :bearer_token (String.t): OAuth bearer token.
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :model (String.t): The &#x60;model&#x60; type requested for this translation. Valid values are listed in public documentation.
     - :source (String.t): The language of the source text, set to one of the language codes listed in Language Support. If the source language is not specified, the API will attempt to identify the source language automatically and return it within the response.
     - :cid ([String.t]): The customization id for translate
     - :format (String.t): The format of the source text, in either HTML (default) or plain-text. A value of \&quot;html\&quot; indicates HTML and a value of \&quot;text\&quot; indicates plain-text.
-    - :model (String.t): The &#x60;model&#x60; type requested for this translation. Valid values are listed in public documentation.
 
   ## Returns
 
@@ -61,23 +61,23 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
           | {:error, Tesla.Env.t()}
   def language_translations_list(connection, q, target, opts \\ []) do
     optional_params = %{
-      :oauth_token => :query,
-      :bearer_token => :query,
       :upload_protocol => :query,
       :prettyPrint => :query,
       :uploadType => :query,
       :fields => :query,
-      :callback => :query,
       :"$.xgafv" => :query,
+      :callback => :query,
       :alt => :query,
       :key => :query,
       :access_token => :query,
       :quotaUser => :query,
       :pp => :query,
+      :bearer_token => :query,
+      :oauth_token => :query,
+      :model => :query,
       :source => :query,
       :cid => :query,
-      :format => :query,
-      :model => :query
+      :format => :query
     }
 
     %{}
@@ -88,7 +88,7 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode(%{"body" => %GoogleApi.Translate.V2.Model.TranslationsListResponse{}})
+    |> decode(%GoogleApi.Translate.V2.Model.TranslationsListResponse{}, dataWrapped: true)
   end
 
   @doc """
@@ -98,20 +98,20 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
 
   - connection (GoogleApi.Translate.V2.Connection): Connection to server
   - opts (KeywordList): [optional] Optional parameters
-    - :oauth_token (String.t): OAuth 2.0 token for the current user.
-    - :bearer_token (String.t): OAuth bearer token.
     - :upload_protocol (String.t): Upload protocol for media (e.g. \&quot;raw\&quot;, \&quot;multipart\&quot;).
     - :prettyPrint (boolean()): Returns response with indentations and line breaks.
     - :uploadType (String.t): Legacy upload protocol for media (e.g. \&quot;media\&quot;, \&quot;multipart\&quot;).
     - :fields (String.t): Selector specifying which fields to include in a partial response.
-    - :callback (String.t): JSONP
     - :$.xgafv (String.t): V1 error format.
+    - :callback (String.t): JSONP
     - :alt (String.t): Data format for response.
     - :key (String.t): API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
     - :access_token (String.t): OAuth access token.
     - :quotaUser (String.t): Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
     - :pp (boolean()): Pretty-print response.
-    - :body (TranslateTextRequest):
+    - :bearer_token (String.t): OAuth bearer token.
+    - :oauth_token (String.t): OAuth 2.0 token for the current user.
+    - :body (TranslateTextRequest): 
 
   ## Returns
 
@@ -123,19 +123,19 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
           | {:error, Tesla.Env.t()}
   def language_translations_translate(connection, opts \\ []) do
     optional_params = %{
-      :oauth_token => :query,
-      :bearer_token => :query,
       :upload_protocol => :query,
       :prettyPrint => :query,
       :uploadType => :query,
       :fields => :query,
-      :callback => :query,
       :"$.xgafv" => :query,
+      :callback => :query,
       :alt => :query,
       :key => :query,
       :access_token => :query,
       :quotaUser => :query,
       :pp => :query,
+      :bearer_token => :query,
+      :oauth_token => :query,
       :body => :body
     }
 
@@ -145,6 +145,6 @@ defmodule GoogleApi.Translate.V2.Api.Translations do
     |> add_optional_params(optional_params, opts)
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode(%GoogleApi.Translate.V2.Model.TranslationsListResponse{}, true)
+    |> decode(%GoogleApi.Translate.V2.Model.TranslationsListResponse{}, dataWrapped: true)
   end
 end

--- a/clients/translate/lib/google_api/translate/v2/request_builder.ex
+++ b/clients/translate/lib/google_api/translate/v2/request_builder.ex
@@ -23,6 +23,11 @@ defmodule GoogleApi.Translate.V2.RequestBuilder do
 
   @path_template_regex ~r/{(\+?[^}]+)}/i
 
+
+  defmodule DataWrapper do
+    defstruct [:data]
+  end
+
   @doc """
   Specify the request method when building a request
 
@@ -176,5 +181,20 @@ defmodule GoogleApi.Translate.V2.RequestBuilder do
 
   def decode(response, _struct) do
     {:error, response}
+  end
+
+  def decode(%Tesla.Env{status: 200, body: body}, struct, true) do
+    {:ok, %{data: data}} = Poison.decode(body, as: %GoogleApi.Translate.V2.RequestBuilder.DataWrapper{}, struct: struct)
+    {:ok, data}
+  end
+
+end
+
+defimpl Poison.Decoder, for: GoogleApi.Translate.V2.RequestBuilder.DataWrapper do
+  import GoogleApi.Translate.V2.Deserializer
+
+  def decode(value, options) do
+    value
+    |> deserialize(:data, :struct, options[:struct], options)
   end
 end

--- a/clients/translate/lib/google_api/translate/v2/request_builder.ex
+++ b/clients/translate/lib/google_api/translate/v2/request_builder.ex
@@ -23,7 +23,6 @@ defmodule GoogleApi.Translate.V2.RequestBuilder do
 
   @path_template_regex ~r/{(\+?[^}]+)}/i
 
-
   defmodule DataWrapper do
     defstruct [:data]
   end
@@ -183,11 +182,16 @@ defmodule GoogleApi.Translate.V2.RequestBuilder do
     {:error, response}
   end
 
-  def decode(%Tesla.Env{status: 200, body: body}, struct, true) do
-    {:ok, %{data: data}} = Poison.decode(body, as: %GoogleApi.Translate.V2.RequestBuilder.DataWrapper{}, struct: struct)
+  def decode(%Tesla.Env{status: 200, body: body}, struct, dataWrapped: true) do
+    {:ok, %{data: data}} =
+      Poison.decode(
+        body,
+        as: %GoogleApi.Translate.V2.RequestBuilder.DataWrapper{},
+        struct: struct
+      )
+
     {:ok, data}
   end
-
 end
 
 defimpl Poison.Decoder, for: GoogleApi.Translate.V2.RequestBuilder.DataWrapper do

--- a/clients/translate/lib/google_api/translate/v2/request_builder.ex
+++ b/clients/translate/lib/google_api/translate/v2/request_builder.ex
@@ -143,8 +143,7 @@ defmodule GoogleApi.Translate.V2.RequestBuilder do
   end
 
   def add_param(request, :form, name, value) do
-    request
-    |> Map.update(:body, %{name => value}, &Map.put(&1, name, value))
+    Map.update(request, :body, %{name => value}, &Map.put(&1, name, value))
   end
 
   def add_param(request, location, key, value) do
@@ -198,7 +197,6 @@ defimpl Poison.Decoder, for: GoogleApi.Translate.V2.RequestBuilder.DataWrapper d
   import GoogleApi.Translate.V2.Deserializer
 
   def decode(value, options) do
-    value
-    |> deserialize(:data, :struct, options[:struct], options)
+    deserialize(value, :data, :struct, options[:struct], options)
   end
 end

--- a/clients/translate/mix.exs
+++ b/clients/translate/mix.exs
@@ -25,7 +25,8 @@ defmodule GoogleApi.Translate.V2.Mixfile do
     [
       {:tesla, "~> 0.5"},
       {:poison, ">= 1.0.0"},
-      {:ex_doc, "~> 0.16", only: :dev}
+      {:ex_doc, "~> 0.16", only: :dev},
+      {:goth, "~> 0.4.0", only: [:dev, :test]}
     ]
   end
 

--- a/clients/translate/test/test_helper.exs
+++ b/clients/translate/test/test_helper.exs
@@ -1,1 +1,18 @@
 ExUnit.start()
+
+defmodule GoogleApi.Translate.V2.TestHelper do
+
+  defmacro __using__(opts) do
+    quote do
+      use ExUnit.Case, unquote(opts)
+      import GoogleApi.Translate.V2.TestHelper
+    end
+  end
+
+  def for_scope(scopes) when is_list(scopes), do: for_scope(Enum.join(scopes, " "))
+  def for_scope(scope) do
+    {:ok, token} = Goth.Token.for_scope(scope)
+    token.token
+  end
+
+end

--- a/clients/translate/test/translate_test.exs
+++ b/clients/translate/test/translate_test.exs
@@ -1,0 +1,18 @@
+defmodule GoogleApi.Translate.TranslateTest do
+  use GoogleApi.Translate.V2.TestHelper
+
+  test "translate" do
+    conn = GoogleApi.Translate.V2.Connection.new(&for_scope/1)
+
+    req = %GoogleApi.Translate.V2.Model.TranslateTextRequest{
+      format: "text",
+      model: "nmt",
+      q: "The quick brown fox jumped over the lazy dog.",
+      source: "en",
+      target: "es"
+    }
+    {:ok, resp} = GoogleApi.Translate.V2.Api.Translations.language_translations_translate(conn, body: req)
+
+    assert %GoogleApi.Translate.V2.Model.TranslationsListResponse{} = resp
+  end
+end

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -54,7 +54,7 @@ defmodule {{moduleName}}.Api.{{classname}} do
 {{/hasOptionalParams}}
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()
-    |> decode({{#vendorExtensions.x-dataWrapper}}%{"body" => {{/vendorExtensions.x-dataWrapper}}{{decodedStruct}}{{#vendorExtensions.x-dataWrapper}}}{{/vendorExtensions.x-dataWrapper}})
+    |> decode({{decodedStruct}}{{#vendorExtensions.x-dataWrapper}}, dataWrapped: true{{/vendorExtensions.x-dataWrapper}})
   end
   {{/operation}}
 {{/operations}}

--- a/template/request_builder.ex.mustache
+++ b/template/request_builder.ex.mustache
@@ -110,8 +110,7 @@ defmodule {{moduleName}}.RequestBuilder do
     |> Map.update!(:body, &(Tesla.Multipart.add_file(&1, path, name: name)))
   end
   def add_param(request, :form, name, value) do
-    request
-    |> Map.update(:body, %{name => value}, &(Map.put(&1, name, value)))
+    Map.update(request, :body, %{name => value}, &(Map.put(&1, name, value)))
   end
   def add_param(request, location, key, value) do
     Map.update(request, location, [{key, value}], &(&1 ++ [{key, value}]))
@@ -153,7 +152,6 @@ defimpl Poison.Decoder, for: {{moduleName}}.RequestBuilder.DataWrapper do
   import {{moduleName}}.Deserializer
 
   def decode(value, options) do
-    value
-    |> deserialize(:data, :struct, options[:struct], options)
+    deserialize(value, :data, :struct, options[:struct], options)
   end
 end

--- a/template/request_builder.ex.mustache
+++ b/template/request_builder.ex.mustache
@@ -6,6 +6,10 @@ defmodule {{moduleName}}.RequestBuilder do
 
   @path_template_regex ~r/{(\+?[^}]+)}/i
 
+  defmodule DataWrapper do
+    defstruct [:data]
+  end
+
   @doc """
   Specify the request method when building a request
 
@@ -138,5 +142,18 @@ defmodule {{moduleName}}.RequestBuilder do
   end
   def decode(response, _struct) do
     {:error, response}
+  end
+  def decode(%Tesla.Env{status: 200, body: body}, struct, dataWrapped: true) do
+    {:ok, %{data: data}} = Poison.decode(body, as: %{{moduleName}}.RequestBuilder.DataWrapper{}, struct: struct)
+    {:ok, data}
+  end
+end
+
+defimpl Poison.Decoder, for: {{moduleName}}.RequestBuilder.DataWrapper do
+  import {{moduleName}}.Deserializer
+
+  def decode(value, options) do
+    value
+    |> deserialize(:data, :struct, options[:struct], options)
   end
 end


### PR DESCRIPTION
For dataWrapped APIs (currently only Translate) we can create a shared `DataWrapper` struct that can decode itself with `Poison` via a provided `option[:struct]` type.