### PR TITLE
Relax tesla dependency to ~> 1.0

### DIFF
--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -26,7 +26,7 @@ defmodule GoogleApi.Gax.MixProject do
 
   defp deps() do
     [
-      {:tesla, "~> 1.0.0"},
+      {:tesla, "~> 1.0"},
       {:poison, ">= 1.0.0"},
       {:ex_doc, "~> 0.16", only: :dev},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false}


### PR DESCRIPTION
Tesla is using semver, any breaking change will be a bump of major version, so it is safe to depend on any `1.x.y`.

(This change is completely unrelated to that fact that I've just released tesla 1.1.0)