### PR TITLE
Fix hex link

### DIFF
--- a/clients/firestore/README.md
+++ b/clients/firestore/README.md
@@ -5,17 +5,16 @@
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `google_cloud_firestore` to your list of dependencies in `mix.exs`:
+by adding `google_api_firestore` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:google_cloud_firestore, "~> 0.0.1"}
+    {:google_api_firestore, "~> 0.0.1"}
   ]
 end
 ```
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/google_cloud_firestore](https://hexdocs.pm/google_cloud_firestore).
-
+be found at [https://hexdocs.pm/google_cloud_firestore](https://hexdocs.pm/google_api_firestore).


### PR DESCRIPTION
google_cloud_firestore doesn't exist on Hex, google_api_firestore does